### PR TITLE
test(bot): add rapid property-based tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,10 @@ expense-bot
 *.cover
 *.html
 
+# rapid property-test failure seeds
+testdata/rapid/
+**/testdata/rapid/
+
 # Go workspace
 go.work
 go.work.sum
@@ -40,7 +44,6 @@ Thumbs.db
 
 # Claude Code local settings
 .claude/
-CLAUDE.md
 .rtk
 
 tmp

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,8 @@ repos:
     rev: v2.11.4
     hooks:
       - id: golangci-lint
+        env:
+          GOTOOLCHAIN: auto
   - repo: https://github.com/koalaman/shellcheck-precommit
     rev: v0.11.0
     hooks:

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
 	google.golang.org/genai v1.54.0
+	pgregory.net/rapid v1.2.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -143,3 +143,5 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EV
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+pgregory.net/rapid v1.2.0 h1:keKAYRcjm+e1F0oAuU5F5+YPAWcyxNNRK2wud503Gnk=
+pgregory.net/rapid v1.2.0/go.mod h1:PY5XlDGj0+V1FCq0o192FdRhpKHGTRIWBgqjDBTrq04=

--- a/internal/bot/category_matcher_rapid_test.go
+++ b/internal/bot/category_matcher_rapid_test.go
@@ -1,0 +1,168 @@
+package bot
+
+import (
+	"strings"
+	"testing"
+
+	"gitlab.com/yelinaung/expense-bot/internal/models"
+	"pgregory.net/rapid"
+)
+
+// genCategoryName generates a category name of 1..3 words from letters.
+func genCategoryName() *rapid.Generator[string] {
+	return rapid.Custom(func(t *rapid.T) string {
+		n := rapid.IntRange(1, 3).Draw(t, "n")
+		words := make([]string, n)
+		for i := range n {
+			words[i] = rapid.StringMatching(`[A-Za-z]{3,10}`).Draw(t, "word")
+		}
+		return strings.Join(words, " ")
+	})
+}
+
+// genCategories generates 1..6 unique-name categories.
+func genCategories() *rapid.Generator[[]models.Category] {
+	return rapid.Custom(func(t *rapid.T) []models.Category {
+		n := rapid.IntRange(1, 6).Draw(t, "n")
+		seen := map[string]bool{}
+		var cats []models.Category
+		attempts := 0
+		for len(cats) < n && attempts < n*4 {
+			name := genCategoryName().Draw(t, "name")
+			key := strings.ToLower(name)
+			if seen[key] {
+				attempts++
+				continue
+			}
+			seen[key] = true
+			cats = append(cats, models.Category{ID: len(cats) + 1, Name: name})
+			attempts++
+		}
+		return cats
+	})
+}
+
+// TestMatchCategoryEmptyInputReturnsNil: blank suggested → nil.
+func TestMatchCategoryEmptyInputReturnsNil(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		cats := genCategories().Draw(t, "cats")
+		spaces := rapid.StringMatching(`[ \t]*`).Draw(t, "spaces")
+		got := MatchCategory(spaces, cats)
+		if got != nil {
+			t.Fatalf("MatchCategory(%q) = %v, want nil", spaces, got)
+		}
+	})
+}
+
+// TestMatchCategoryEmptyCategoriesReturnsNil: no categories → nil.
+func TestMatchCategoryEmptyCategoriesReturnsNil(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		s := rapid.StringMatching(`[A-Za-z ]{1,20}`).Draw(t, "s")
+		got := MatchCategory(s, nil)
+		if got != nil {
+			t.Fatalf("MatchCategory(%q, nil) = %v, want nil", s, got)
+		}
+	})
+}
+
+// TestMatchCategoryExactCaseInsensitive: exact (case-insensitive) name always matches.
+func TestMatchCategoryExactCaseInsensitive(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		cats := genCategories().Draw(t, "cats")
+		idx := rapid.IntRange(0, len(cats)-1).Draw(t, "idx")
+		target := cats[idx].Name
+		upper := rapid.Bool().Draw(t, "upper")
+		suggested := target
+		if upper {
+			suggested = strings.ToUpper(target)
+		} else {
+			suggested = strings.ToLower(target)
+		}
+
+		got := MatchCategory(suggested, cats)
+		if got == nil {
+			t.Fatalf("MatchCategory(%q) = nil, want match", suggested)
+		}
+		if !strings.EqualFold(got.Name, target) {
+			t.Fatalf("MatchCategory(%q) = %q, want equalfold %q", suggested, got.Name, target)
+		}
+	})
+}
+
+// TestMatchCategoryDeterministic: same inputs → same result.
+func TestMatchCategoryDeterministic(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		cats := genCategories().Draw(t, "cats")
+		s := rapid.StringMatching(`[A-Za-z ]{1,20}`).Draw(t, "s")
+		a := MatchCategory(s, cats)
+		b := MatchCategory(s, cats)
+		switch {
+		case a == nil && b == nil:
+			return
+		case a == nil || b == nil:
+			t.Fatalf("nondeterministic: %v vs %v", a, b)
+		case a.ID != b.ID:
+			t.Fatalf("nondeterministic match id: %d vs %d", a.ID, b.ID)
+		}
+	})
+}
+
+// TestExtractSignificantWordsFiltersStopAndShort: all words ≥3 chars, none are stop words,
+// contain no separator chars.
+func TestExtractSignificantWordsFiltersStopAndShort(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		s := rapid.StringMatching(`[A-Za-z &/\- ]{0,40}`).Draw(t, "s")
+		words := extractSignificantWords(s)
+		for _, w := range words {
+			if len(w) < 3 {
+				t.Fatalf("short word: %q (input=%q)", w, s)
+			}
+			if isStopWord(w) {
+				t.Fatalf("stop word returned: %q", w)
+			}
+			if strings.ContainsAny(w, "-/&") {
+				t.Fatalf("word contains separator: %q", w)
+			}
+			if w != strings.ToLower(w) {
+				t.Fatalf("word not lowercased: %q", w)
+			}
+		}
+	})
+}
+
+// TestIsStopWordFixedSet: only "and", "the", "for" are stop words.
+func TestIsStopWordFixedSet(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		s := rapid.StringMatching(`[a-z]{0,10}`).Draw(t, "s")
+		want := s == "and" || s == "the" || s == "for"
+		got := isStopWord(s)
+		if got != want {
+			t.Fatalf("isStopWord(%q) = %v, want %v", s, got, want)
+		}
+	})
+}
+
+// TestMatchCategorySubstringFinds: when suggested is substring of some category
+// name (case-insensitive), Match returns non-nil.
+func TestMatchCategorySubstringFinds(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		cats := genCategories().Draw(t, "cats")
+		idx := rapid.IntRange(0, len(cats)-1).Draw(t, "idx")
+		target := cats[idx].Name
+		// Use a non-empty case-insensitive substring of target.
+		if strings.TrimSpace(target) == "" {
+			t.Skip("empty target")
+		}
+		start := rapid.IntRange(0, len(target)-1).Draw(t, "start")
+		end := rapid.IntRange(start+1, len(target)).Draw(t, "end")
+		sub := strings.TrimSpace(target[start:end])
+		if sub == "" {
+			t.Skip("empty substring")
+		}
+
+		got := MatchCategory(sub, cats)
+		if got == nil {
+			t.Fatalf("MatchCategory(%q) = nil, expected some category containing it (target=%q)", sub, target)
+		}
+	})
+}

--- a/internal/bot/category_matcher_rapid_test.go
+++ b/internal/bot/category_matcher_rapid_test.go
@@ -72,7 +72,7 @@ func TestMatchCategoryExactCaseInsensitive(t *testing.T) {
 		idx := rapid.IntRange(0, len(cats)-1).Draw(t, "idx")
 		target := cats[idx].Name
 		upper := rapid.Bool().Draw(t, "upper")
-		suggested := target
+		var suggested string
 		if upper {
 			suggested = strings.ToUpper(target)
 		} else {
@@ -82,6 +82,7 @@ func TestMatchCategoryExactCaseInsensitive(t *testing.T) {
 		got := MatchCategory(suggested, cats)
 		if got == nil {
 			t.Fatalf("MatchCategory(%q) = nil, want match", suggested)
+			return
 		}
 		if !strings.EqualFold(got.Name, target) {
 			t.Fatalf("MatchCategory(%q) = %q, want equalfold %q", suggested, got.Name, target)

--- a/internal/bot/category_matcher_rapid_test.go
+++ b/internal/bot/category_matcher_rapid_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"gitlab.com/yelinaung/expense-bot/internal/models"
 	"pgregory.net/rapid"
 )
@@ -21,22 +22,20 @@ func genCategoryName() *rapid.Generator[string] {
 }
 
 // genCategories generates 1..6 unique-name categories.
+// Guarantees at least one category so draws like IntRange(0, len(cats)-1) are safe.
 func genCategories() *rapid.Generator[[]models.Category] {
 	return rapid.Custom(func(t *rapid.T) []models.Category {
 		n := rapid.IntRange(1, 6).Draw(t, "n")
 		seen := map[string]bool{}
-		var cats []models.Category
-		attempts := 0
-		for len(cats) < n && attempts < n*4 {
+		cats := make([]models.Category, 0, n)
+		for len(cats) < n {
 			name := genCategoryName().Draw(t, "name")
 			key := strings.ToLower(name)
 			if seen[key] {
-				attempts++
 				continue
 			}
 			seen[key] = true
 			cats = append(cats, models.Category{ID: len(cats) + 1, Name: name})
-			attempts++
 		}
 		return cats
 	})
@@ -44,29 +43,40 @@ func genCategories() *rapid.Generator[[]models.Category] {
 
 // TestMatchCategoryEmptyInputReturnsNil: blank suggested → nil.
 func TestMatchCategoryEmptyInputReturnsNil(t *testing.T) {
+	t.Parallel()
 	rapid.Check(t, func(t *rapid.T) {
 		cats := genCategories().Draw(t, "cats")
 		spaces := rapid.StringMatching(`[ \t]*`).Draw(t, "spaces")
 		got := MatchCategory(spaces, cats)
-		if got != nil {
-			t.Fatalf("MatchCategory(%q) = %v, want nil", spaces, got)
-		}
+		require.Nil(t, got, "MatchCategory(%q)", spaces)
 	})
 }
 
-// TestMatchCategoryEmptyCategoriesReturnsNil: no categories → nil.
+// TestMatchCategoryEmptyCategoriesReturnsNil: nil or empty-slice → nil.
 func TestMatchCategoryEmptyCategoriesReturnsNil(t *testing.T) {
-	rapid.Check(t, func(t *rapid.T) {
-		s := rapid.StringMatching(`[A-Za-z ]{1,20}`).Draw(t, "s")
-		got := MatchCategory(s, nil)
-		if got != nil {
-			t.Fatalf("MatchCategory(%q, nil) = %v, want nil", s, got)
-		}
-	})
+	t.Parallel()
+	cases := []struct {
+		name       string
+		categories []models.Category
+	}{
+		{"nil", nil},
+		{"empty", []models.Category{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			rapid.Check(t, func(t *rapid.T) {
+				s := rapid.StringMatching(`[A-Za-z ]{1,20}`).Draw(t, "s")
+				got := MatchCategory(s, tc.categories)
+				require.Nil(t, got, "MatchCategory(%q, %s)", s, tc.name)
+			})
+		})
+	}
 }
 
 // TestMatchCategoryExactCaseInsensitive: exact (case-insensitive) name always matches.
 func TestMatchCategoryExactCaseInsensitive(t *testing.T) {
+	t.Parallel()
 	rapid.Check(t, func(t *rapid.T) {
 		cats := genCategories().Draw(t, "cats")
 		idx := rapid.IntRange(0, len(cats)-1).Draw(t, "idx")
@@ -80,18 +90,15 @@ func TestMatchCategoryExactCaseInsensitive(t *testing.T) {
 		}
 
 		got := MatchCategory(suggested, cats)
-		if got == nil {
-			t.Fatalf("MatchCategory(%q) = nil, want match", suggested)
-			return
-		}
-		if !strings.EqualFold(got.Name, target) {
-			t.Fatalf("MatchCategory(%q) = %q, want equalfold %q", suggested, got.Name, target)
-		}
+		require.NotNil(t, got, "MatchCategory(%q)", suggested)
+		require.True(t, strings.EqualFold(got.Name, target),
+			"MatchCategory(%q) = %q, want equalfold %q", suggested, got.Name, target)
 	})
 }
 
 // TestMatchCategoryDeterministic: same inputs → same result.
 func TestMatchCategoryDeterministic(t *testing.T) {
+	t.Parallel()
 	rapid.Check(t, func(t *rapid.T) {
 		cats := genCategories().Draw(t, "cats")
 		s := rapid.StringMatching(`[A-Za-z ]{1,20}`).Draw(t, "s")
@@ -101,9 +108,10 @@ func TestMatchCategoryDeterministic(t *testing.T) {
 		case a == nil && b == nil:
 			return
 		case a == nil || b == nil:
-			t.Fatalf("nondeterministic: %v vs %v", a, b)
-		case a.ID != b.ID:
-			t.Fatalf("nondeterministic match id: %d vs %d", a.ID, b.ID)
+			require.FailNowf(t, "nondeterministic nil",
+				"a=%v b=%v", a, b)
+		default:
+			require.Equal(t, a.ID, b.ID, "nondeterministic match id")
 		}
 	})
 }
@@ -111,46 +119,38 @@ func TestMatchCategoryDeterministic(t *testing.T) {
 // TestExtractSignificantWordsFiltersStopAndShort: all words ≥3 chars, none are stop words,
 // contain no separator chars.
 func TestExtractSignificantWordsFiltersStopAndShort(t *testing.T) {
+	t.Parallel()
 	rapid.Check(t, func(t *rapid.T) {
 		s := rapid.StringMatching(`[A-Za-z &/\- ]{0,40}`).Draw(t, "s")
 		words := extractSignificantWords(s)
 		for _, w := range words {
-			if len(w) < 3 {
-				t.Fatalf("short word: %q (input=%q)", w, s)
-			}
-			if isStopWord(w) {
-				t.Fatalf("stop word returned: %q", w)
-			}
-			if strings.ContainsAny(w, "-/&") {
-				t.Fatalf("word contains separator: %q", w)
-			}
-			if w != strings.ToLower(w) {
-				t.Fatalf("word not lowercased: %q", w)
-			}
+			require.GreaterOrEqual(t, len(w), 3, "short word: %q (input=%q)", w, s)
+			require.False(t, isStopWord(w), "stop word returned: %q", w)
+			require.False(t, strings.ContainsAny(w, "-/&"), "word contains separator: %q", w)
+			require.Equal(t, strings.ToLower(w), w, "word not lowercased: %q", w)
 		}
 	})
 }
 
 // TestIsStopWordFixedSet: only "and", "the", "for" are stop words.
 func TestIsStopWordFixedSet(t *testing.T) {
+	t.Parallel()
 	rapid.Check(t, func(t *rapid.T) {
 		s := rapid.StringMatching(`[a-z]{0,10}`).Draw(t, "s")
 		want := s == "and" || s == "the" || s == "for"
 		got := isStopWord(s)
-		if got != want {
-			t.Fatalf("isStopWord(%q) = %v, want %v", s, got, want)
-		}
+		require.Equal(t, want, got, "isStopWord(%q)", s)
 	})
 }
 
 // TestMatchCategorySubstringFinds: when suggested is substring of some category
 // name (case-insensitive), Match returns non-nil.
 func TestMatchCategorySubstringFinds(t *testing.T) {
+	t.Parallel()
 	rapid.Check(t, func(t *rapid.T) {
 		cats := genCategories().Draw(t, "cats")
 		idx := rapid.IntRange(0, len(cats)-1).Draw(t, "idx")
 		target := cats[idx].Name
-		// Use a non-empty case-insensitive substring of target.
 		if strings.TrimSpace(target) == "" {
 			t.Skip("empty target")
 		}
@@ -162,8 +162,7 @@ func TestMatchCategorySubstringFinds(t *testing.T) {
 		}
 
 		got := MatchCategory(sub, cats)
-		if got == nil {
-			t.Fatalf("MatchCategory(%q) = nil, expected some category containing it (target=%q)", sub, target)
-		}
+		require.NotNil(t, got,
+			"MatchCategory(%q) expected match (target=%q)", sub, target)
 	})
 }

--- a/internal/bot/category_matcher_rapid_test.go
+++ b/internal/bot/category_matcher_rapid_test.go
@@ -132,7 +132,10 @@ func TestExtractSignificantWordsFiltersStopAndShort(t *testing.T) {
 	})
 }
 
-// TestIsStopWordFixedSet: only "and", "the", "for" are stop words.
+// TestIsStopWordFixedSet pins the current stop-word set as a contract: only
+// "and", "the", "for" are recognized. Update this test when the stop-word list
+// changes — the pin exists so additions or removals are a deliberate, visible
+// change rather than a silent behavior shift.
 func TestIsStopWordFixedSet(t *testing.T) {
 	t.Parallel()
 	rapid.Check(t, func(t *rapid.T) {
@@ -143,8 +146,12 @@ func TestIsStopWordFixedSet(t *testing.T) {
 	})
 }
 
-// TestMatchCategorySubstringFinds: when suggested is substring of some category
-// name (case-insensitive), Match returns non-nil.
+// TestMatchCategorySubstringFinds asserts the substring-containment contract:
+// when suggested is a non-empty substring of any category name,
+// MatchCategory returns some category (not necessarily the target — the
+// shortest containing category or first word-based hit is acceptable). This
+// pins the "never miss a clear containment hit" behavior without constraining
+// which category wins when multiple candidates contain the substring.
 func TestMatchCategorySubstringFinds(t *testing.T) {
 	t.Parallel()
 	rapid.Check(t, func(t *rapid.T) {

--- a/internal/bot/category_matcher_rapid_test.go
+++ b/internal/bot/category_matcher_rapid_test.go
@@ -146,6 +146,47 @@ func TestIsStopWordFixedSet(t *testing.T) {
 	})
 }
 
+// TestFindWordBasedCategoryMatchNoSignificantWordsReturnsNil: when the
+// suggested input contains only stop words or sub-3-character tokens,
+// extractSignificantWords returns an empty slice and the word-based matcher
+// must not fall back to any accidental hit.
+//
+// Scoped to findWordBasedCategoryMatch specifically because
+// findShortestContainingCategoryMatch can legitimately match on a 1-char
+// substring of a cat name (e.g. "a" is a substring of "aaa") — that's not a
+// spurious hit, so end-to-end MatchCategory can't assert nil here.
+func TestFindWordBasedCategoryMatchNoSignificantWordsReturnsNil(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(t *rapid.T) {
+		cats := genCategories().Draw(t, "cats")
+		kind := rapid.IntRange(0, 1).Draw(t, "kind")
+		var suggested string
+		switch kind {
+		case 0:
+			// Only stop words, space-separated.
+			n := rapid.IntRange(1, 5).Draw(t, "n")
+			toks := make([]string, n)
+			for i := range n {
+				toks[i] = rapid.SampledFrom([]string{"and", "the", "for"}).Draw(t, "stop")
+			}
+			suggested = strings.Join(toks, " ")
+		default:
+			// Only sub-3-character letter tokens.
+			n := rapid.IntRange(1, 5).Draw(t, "n")
+			toks := make([]string, n)
+			for i := range n {
+				toks[i] = rapid.StringMatching(`[A-Za-z]{1,2}`).Draw(t, "tok")
+			}
+			suggested = strings.Join(toks, " ")
+		}
+
+		require.Empty(t, extractSignificantWords(suggested),
+			"precondition: expected no significant words in %q", suggested)
+		got := findWordBasedCategoryMatch(suggested, cats)
+		require.Nil(t, got, "findWordBasedCategoryMatch(%q)", suggested)
+	})
+}
+
 // TestMatchCategorySubstringFinds asserts the substring-containment contract:
 // when suggested is a non-empty substring of any category name,
 // MatchCategory returns some category (not necessarily the target — the

--- a/internal/bot/csv_generator_rapid_test.go
+++ b/internal/bot/csv_generator_rapid_test.go
@@ -1,0 +1,162 @@
+package bot
+
+import (
+	"bytes"
+	"encoding/csv"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/require"
+	"gitlab.com/yelinaung/expense-bot/internal/models"
+	"pgregory.net/rapid"
+)
+
+// genSupportedCurrency draws a sorted-stable currency code.
+func genSupportedCurrency() *rapid.Generator[string] {
+	codes := make([]string, 0, len(models.SupportedCurrencies))
+	for c := range models.SupportedCurrencies {
+		codes = append(codes, c)
+	}
+	sort.Strings(codes)
+	return rapid.SampledFrom(codes)
+}
+
+// genCreatedAt draws a UTC time between 2000 and 2040.
+func genCreatedAt() *rapid.Generator[time.Time] {
+	return rapid.Custom(func(t *rapid.T) time.Time {
+		year := rapid.IntRange(2000, 2040).Draw(t, "year")
+		month := rapid.IntRange(1, 12).Draw(t, "month")
+		day := rapid.IntRange(1, 28).Draw(t, "day")
+		hour := rapid.IntRange(0, 23).Draw(t, "hour")
+		minute := rapid.IntRange(0, 59).Draw(t, "minute")
+		second := rapid.IntRange(0, 59).Draw(t, "second")
+		return time.Date(year, time.Month(month), day, hour, minute, second, 0, time.UTC)
+	})
+}
+
+// csvFormulaChars lists the leading characters sanitizeCSVCell must neutralize.
+const csvFormulaChars = "=+-@\t\r"
+
+// TestSanitizeCSVCellEmptyStays: empty in → empty out.
+func TestSanitizeCSVCellEmptyStays(t *testing.T) {
+	t.Parallel()
+	require.Empty(t, sanitizeCSVCell(""))
+}
+
+// TestSanitizeCSVCellIdempotent: sanitizing twice equals sanitizing once.
+func TestSanitizeCSVCellIdempotent(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(t *rapid.T) {
+		s := rapid.String().Draw(t, "s")
+		once := sanitizeCSVCell(s)
+		twice := sanitizeCSVCell(once)
+		require.Equal(t, once, twice, "not idempotent (in=%q)", s)
+	})
+}
+
+// TestSanitizeCSVCellPrefixesFormulaStart: cells whose first non-space char is
+// a formula char are prefixed with a single quote.
+func TestSanitizeCSVCellPrefixesFormulaStart(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(t *rapid.T) {
+		leadingSpaces := rapid.StringMatching(` {0,5}`).Draw(t, "spaces")
+		first := rapid.SampledFrom([]byte(csvFormulaChars)).Draw(t, "first")
+		tail := rapid.StringMatching(`[A-Za-z0-9 ]{0,20}`).Draw(t, "tail")
+		s := leadingSpaces + string(first) + tail
+
+		got := sanitizeCSVCell(s)
+		require.Equal(t, "'"+s, got, "input=%q", s)
+	})
+}
+
+// TestSanitizeCSVCellSafeUnchanged: cells that start (after trim) with a safe
+// character are returned unchanged.
+func TestSanitizeCSVCellSafeUnchanged(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(t *rapid.T) {
+		leadingSpaces := rapid.StringMatching(` {0,5}`).Draw(t, "spaces")
+		// First non-space char must be safe.
+		first := rapid.StringMatching(`[A-Za-z0-9!?#$%^&*()_.,;:"'/\\]`).Draw(t, "first")
+		if strings.ContainsAny(first, csvFormulaChars) {
+			t.Skip("first char is a formula char")
+		}
+		tail := rapid.String().Draw(t, "tail")
+		s := leadingSpaces + first + tail
+		// Reject if the whole thing becomes empty after trim (covered elsewhere).
+		if strings.TrimLeft(s, " ") == "" {
+			t.Skip("empty after trim")
+		}
+
+		got := sanitizeCSVCell(s)
+		require.Equal(t, s, got, "input=%q", s)
+	})
+}
+
+// TestGenerateExpensesCSVStructure: output parses as CSV with N+1 rows (header+rows)
+// and 7 fields per row.
+func TestGenerateExpensesCSVStructure(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(t *rapid.T) {
+		n := rapid.IntRange(0, 10).Draw(t, "n")
+		exps := make([]models.Expense, n)
+		for i := range n {
+			exps[i] = models.Expense{
+				UserExpenseNumber: int64(i + 1),
+				Amount:            decimal.NewFromInt(int64(i + 1)),
+				Currency:          genSupportedCurrency().Draw(t, "currency"),
+				Description:       rapid.StringMatching(`[A-Za-z0-9 ]{0,20}`).Draw(t, "desc"),
+				Merchant:          rapid.StringMatching(`[A-Za-z0-9 ]{0,20}`).Draw(t, "merch"),
+				CreatedAt:         genCreatedAt().Draw(t, "createdAt"),
+			}
+		}
+
+		data, err := GenerateExpensesCSV(exps)
+		require.NoError(t, err)
+
+		reader := csv.NewReader(bytes.NewReader(data))
+		rows, err := reader.ReadAll()
+		require.NoError(t, err)
+		require.Len(t, rows, n+1, "row count")
+		for _, row := range rows {
+			require.Len(t, row, 7, "field count")
+		}
+		// Header fixed.
+		require.Equal(t,
+			[]string{"ID", "Date", "Amount", "Currency", "Description", "Merchant", "Category"},
+			rows[0])
+	})
+}
+
+// TestGenerateExpensesCSVNeutralizesFormulas: formula-leading description/merchant
+// fields appear prefixed with a single quote in the CSV output.
+func TestGenerateExpensesCSVNeutralizesFormulas(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(t *rapid.T) {
+		first := rapid.SampledFrom([]byte(csvFormulaChars)).Draw(t, "first")
+		tail := rapid.StringMatching(`[A-Za-z0-9 ]{0,10}`).Draw(t, "tail")
+		injected := string(first) + tail
+
+		exps := []models.Expense{{
+			UserExpenseNumber: 1,
+			Amount:            decimal.NewFromInt(1),
+			Currency:          genSupportedCurrency().Draw(t, "currency"),
+			Description:       injected,
+			Merchant:          injected,
+			CreatedAt:         genCreatedAt().Draw(t, "createdAt"),
+		}}
+
+		data, err := GenerateExpensesCSV(exps)
+		require.NoError(t, err)
+
+		reader := csv.NewReader(bytes.NewReader(data))
+		rows, err := reader.ReadAll()
+		require.NoError(t, err)
+		require.Len(t, rows, 2)
+
+		require.Equal(t, "'"+injected, rows[1][4], "description cell")
+		require.Equal(t, "'"+injected, rows[1][5], "merchant cell")
+	})
+}

--- a/internal/bot/csv_generator_rapid_test.go
+++ b/internal/bot/csv_generator_rapid_test.go
@@ -3,7 +3,6 @@ package bot
 import (
 	"bytes"
 	"encoding/csv"
-	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -13,16 +12,6 @@ import (
 	"gitlab.com/yelinaung/expense-bot/internal/models"
 	"pgregory.net/rapid"
 )
-
-// genSupportedCurrency draws a sorted-stable currency code.
-func genSupportedCurrency() *rapid.Generator[string] {
-	codes := make([]string, 0, len(models.SupportedCurrencies))
-	for c := range models.SupportedCurrencies {
-		codes = append(codes, c)
-	}
-	sort.Strings(codes)
-	return rapid.SampledFrom(codes)
-}
 
 // genCreatedAt draws a UTC time between 2000 and 2040.
 func genCreatedAt() *rapid.Generator[time.Time] {

--- a/internal/bot/currency_conversion_rapid_test.go
+++ b/internal/bot/currency_conversion_rapid_test.go
@@ -1,7 +1,6 @@
 package bot
 
 import (
-	"sort"
 	"strings"
 	"testing"
 
@@ -36,13 +35,8 @@ func TestNormalizeCurrencyCodeUppercaseTrimmed(t *testing.T) {
 // TestGetCurrencyOrCodeSymbolSupportedReturnsSymbol: for supported codes, returns symbol.
 func TestGetCurrencyOrCodeSymbolSupportedReturnsSymbol(t *testing.T) {
 	t.Parallel()
-	codes := make([]string, 0, len(appmodels.SupportedCurrencies))
-	for c := range appmodels.SupportedCurrencies {
-		codes = append(codes, c)
-	}
-	sort.Strings(codes)
 	rapid.Check(t, func(t *rapid.T) {
-		code := rapid.SampledFrom(codes).Draw(t, "code")
+		code := genSupportedCurrency().Draw(t, "code")
 		got := getCurrencyOrCodeSymbol(code)
 		want := appmodels.SupportedCurrencies[code]
 		require.Equal(t, want, got, "code=%q", code)

--- a/internal/bot/currency_conversion_rapid_test.go
+++ b/internal/bot/currency_conversion_rapid_test.go
@@ -1,0 +1,146 @@
+package bot
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/shopspring/decimal"
+	appmodels "gitlab.com/yelinaung/expense-bot/internal/models"
+	"pgregory.net/rapid"
+)
+
+// TestNormalizeCurrencyCodeIdempotent: norm(norm(x)) == norm(x).
+func TestNormalizeCurrencyCodeIdempotent(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		s := rapid.String().Draw(t, "s")
+		once := normalizeCurrencyCode(s)
+		twice := normalizeCurrencyCode(once)
+		if once != twice {
+			t.Fatalf("not idempotent: once=%q twice=%q (in=%q)", once, twice, s)
+		}
+	})
+}
+
+// TestNormalizeCurrencyCodeUppercaseTrimmed: output is uppercased and has no
+// leading/trailing whitespace.
+func TestNormalizeCurrencyCodeUppercaseTrimmed(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		s := rapid.String().Draw(t, "s")
+		got := normalizeCurrencyCode(s)
+		if got != strings.ToUpper(got) {
+			t.Fatalf("not uppercased: %q", got)
+		}
+		if got != strings.TrimSpace(got) {
+			t.Fatalf("not trimmed: %q", got)
+		}
+	})
+}
+
+// TestGetCurrencyOrCodeSymbolSupportedReturnsSymbol: for supported codes, returns symbol.
+func TestGetCurrencyOrCodeSymbolSupportedReturnsSymbol(t *testing.T) {
+	codes := make([]string, 0, len(appmodels.SupportedCurrencies))
+	for c := range appmodels.SupportedCurrencies {
+		codes = append(codes, c)
+	}
+	rapid.Check(t, func(t *rapid.T) {
+		code := rapid.SampledFrom(codes).Draw(t, "code")
+		got := getCurrencyOrCodeSymbol(code)
+		want := appmodels.SupportedCurrencies[code]
+		if got != want {
+			t.Fatalf("getCurrencyOrCodeSymbol(%q) = %q, want %q", code, got, want)
+		}
+	})
+}
+
+// TestGetCurrencyOrCodeSymbolUnknownReturnsCode: unsupported code → returns code verbatim.
+func TestGetCurrencyOrCodeSymbolUnknownReturnsCode(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		// Generate arbitrary string, skip if it happens to be a known code.
+		code := rapid.String().Draw(t, "code")
+		if _, ok := appmodels.SupportedCurrencies[code]; ok {
+			t.Skip("known code")
+		}
+		if appmodels.SupportedCurrencies[code] != "" {
+			t.Skip("known code")
+		}
+		got := getCurrencyOrCodeSymbol(code)
+		if got != code {
+			t.Fatalf("getCurrencyOrCodeSymbol(%q) = %q, want %q", code, got, code)
+		}
+	})
+}
+
+// genAmount generates a positive decimal with up to 4 fractional digits.
+func genAmount() *rapid.Generator[decimal.Decimal] {
+	return rapid.Custom(func(t *rapid.T) decimal.Decimal {
+		v := rapid.IntRange(1, 1_000_000).Draw(t, "v")
+		exp := rapid.IntRange(-4, 2).Draw(t, "exp")
+		return decimal.New(int64(v), int32(exp))
+	})
+}
+
+// TestAppendOriginalAmountDescriptionInvariants:
+//   - Result contains "orig:" marker
+//   - Result contains original currency and converted currency codes
+//   - Non-empty trimmed description is preserved as prefix
+func TestAppendOriginalAmountDescriptionInvariants(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		desc := rapid.StringMatching(`[A-Za-z ]{0,20}`).Draw(t, "desc")
+		origAmt := genAmount().Draw(t, "origAmt")
+		convAmt := genAmount().Draw(t, "convAmt")
+		rate := genAmount().Draw(t, "rate")
+		origCur := rapid.StringMatching(`[A-Z]{3}`).Draw(t, "origCur")
+		convCur := rapid.StringMatching(`[A-Z]{3}`).Draw(t, "convCur")
+		rateDate := "2026-04-18"
+
+		got := appendOriginalAmountDescription(desc, origAmt, origCur, convAmt, convCur, rate, rateDate)
+
+		if !strings.Contains(got, "orig:") {
+			t.Fatalf("missing 'orig:' marker: %q", got)
+		}
+		if !strings.Contains(got, origCur) {
+			t.Fatalf("missing origCur %q: %q", origCur, got)
+		}
+		if !strings.Contains(got, convCur) {
+			t.Fatalf("missing convCur %q: %q", convCur, got)
+		}
+		if !strings.Contains(got, rateDate) {
+			t.Fatalf("missing rateDate: %q", got)
+		}
+
+		trimmed := strings.TrimSpace(desc)
+		if trimmed != "" {
+			if !strings.HasPrefix(got, desc+" ") {
+				t.Fatalf("prefix not preserved: desc=%q got=%q", desc, got)
+			}
+		}
+	})
+}
+
+// TestAppendConversionUnavailableDescriptionInvariants: contains marker and currencies.
+func TestAppendConversionUnavailableDescriptionInvariants(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		desc := rapid.StringMatching(`[A-Za-z ]{0,20}`).Draw(t, "desc")
+		origCur := rapid.StringMatching(`[A-Z]{3}`).Draw(t, "origCur")
+		targetCur := rapid.StringMatching(`[A-Z]{3}`).Draw(t, "targetCur")
+
+		got := appendConversionUnavailableDescription(desc, origCur, targetCur)
+
+		if !strings.Contains(got, "fx_unavailable") {
+			t.Fatalf("missing fx_unavailable marker: %q", got)
+		}
+		if !strings.Contains(got, origCur) {
+			t.Fatalf("missing origCur %q: %q", origCur, got)
+		}
+		if !strings.Contains(got, targetCur) {
+			t.Fatalf("missing targetCur %q: %q", targetCur, got)
+		}
+
+		trimmed := strings.TrimSpace(desc)
+		if trimmed != "" {
+			if !strings.HasPrefix(got, desc+" ") {
+				t.Fatalf("prefix not preserved: desc=%q got=%q", desc, got)
+			}
+		}
+	})
+}

--- a/internal/bot/currency_conversion_rapid_test.go
+++ b/internal/bot/currency_conversion_rapid_test.go
@@ -1,61 +1,58 @@
 package bot
 
 import (
+	"sort"
 	"strings"
 	"testing"
 
 	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/require"
 	appmodels "gitlab.com/yelinaung/expense-bot/internal/models"
 	"pgregory.net/rapid"
 )
 
 // TestNormalizeCurrencyCodeIdempotent: norm(norm(x)) == norm(x).
 func TestNormalizeCurrencyCodeIdempotent(t *testing.T) {
+	t.Parallel()
 	rapid.Check(t, func(t *rapid.T) {
 		s := rapid.String().Draw(t, "s")
 		once := normalizeCurrencyCode(s)
 		twice := normalizeCurrencyCode(once)
-		if once != twice {
-			t.Fatalf("not idempotent: once=%q twice=%q (in=%q)", once, twice, s)
-		}
+		require.Equal(t, once, twice, "not idempotent (in=%q)", s)
 	})
 }
 
-// TestNormalizeCurrencyCodeUppercaseTrimmed: output is uppercased and has no
-// leading/trailing whitespace.
+// TestNormalizeCurrencyCodeUppercaseTrimmed: output is uppercased and trimmed.
 func TestNormalizeCurrencyCodeUppercaseTrimmed(t *testing.T) {
+	t.Parallel()
 	rapid.Check(t, func(t *rapid.T) {
 		s := rapid.String().Draw(t, "s")
 		got := normalizeCurrencyCode(s)
-		if got != strings.ToUpper(got) {
-			t.Fatalf("not uppercased: %q", got)
-		}
-		if got != strings.TrimSpace(got) {
-			t.Fatalf("not trimmed: %q", got)
-		}
+		require.Equal(t, strings.ToUpper(got), got, "not uppercased: %q", got)
+		require.Equal(t, strings.TrimSpace(got), got, "not trimmed: %q", got)
 	})
 }
 
 // TestGetCurrencyOrCodeSymbolSupportedReturnsSymbol: for supported codes, returns symbol.
 func TestGetCurrencyOrCodeSymbolSupportedReturnsSymbol(t *testing.T) {
+	t.Parallel()
 	codes := make([]string, 0, len(appmodels.SupportedCurrencies))
 	for c := range appmodels.SupportedCurrencies {
 		codes = append(codes, c)
 	}
+	sort.Strings(codes)
 	rapid.Check(t, func(t *rapid.T) {
 		code := rapid.SampledFrom(codes).Draw(t, "code")
 		got := getCurrencyOrCodeSymbol(code)
 		want := appmodels.SupportedCurrencies[code]
-		if got != want {
-			t.Fatalf("getCurrencyOrCodeSymbol(%q) = %q, want %q", code, got, want)
-		}
+		require.Equal(t, want, got, "code=%q", code)
 	})
 }
 
 // TestGetCurrencyOrCodeSymbolUnknownReturnsCode: unsupported code → returns code verbatim.
 func TestGetCurrencyOrCodeSymbolUnknownReturnsCode(t *testing.T) {
+	t.Parallel()
 	rapid.Check(t, func(t *rapid.T) {
-		// Generate arbitrary string, skip if it happens to be a known code.
 		code := rapid.String().Draw(t, "code")
 		if _, ok := appmodels.SupportedCurrencies[code]; ok {
 			t.Skip("known code")
@@ -64,9 +61,7 @@ func TestGetCurrencyOrCodeSymbolUnknownReturnsCode(t *testing.T) {
 			t.Skip("known code")
 		}
 		got := getCurrencyOrCodeSymbol(code)
-		if got != code {
-			t.Fatalf("getCurrencyOrCodeSymbol(%q) = %q, want %q", code, got, code)
-		}
+		require.Equal(t, code, got, "code=%q", code)
 	})
 }
 
@@ -84,6 +79,7 @@ func genAmount() *rapid.Generator[decimal.Decimal] {
 //   - Result contains original currency and converted currency codes
 //   - Non-empty trimmed description is preserved as prefix
 func TestAppendOriginalAmountDescriptionInvariants(t *testing.T) {
+	t.Parallel()
 	rapid.Check(t, func(t *rapid.T) {
 		desc := rapid.StringMatching(`[A-Za-z ]{0,20}`).Draw(t, "desc")
 		origAmt := genAmount().Draw(t, "origAmt")
@@ -95,30 +91,21 @@ func TestAppendOriginalAmountDescriptionInvariants(t *testing.T) {
 
 		got := appendOriginalAmountDescription(desc, origAmt, origCur, convAmt, convCur, rate, rateDate)
 
-		if !strings.Contains(got, "orig:") {
-			t.Fatalf("missing 'orig:' marker: %q", got)
-		}
-		if !strings.Contains(got, origCur) {
-			t.Fatalf("missing origCur %q: %q", origCur, got)
-		}
-		if !strings.Contains(got, convCur) {
-			t.Fatalf("missing convCur %q: %q", convCur, got)
-		}
-		if !strings.Contains(got, rateDate) {
-			t.Fatalf("missing rateDate: %q", got)
-		}
+		require.Contains(t, got, "orig:", "missing marker")
+		require.Contains(t, got, origCur)
+		require.Contains(t, got, convCur)
+		require.Contains(t, got, rateDate)
 
-		trimmed := strings.TrimSpace(desc)
-		if trimmed != "" {
-			if !strings.HasPrefix(got, desc+" ") {
-				t.Fatalf("prefix not preserved: desc=%q got=%q", desc, got)
-			}
+		if strings.TrimSpace(desc) != "" {
+			require.True(t, strings.HasPrefix(got, desc+" "),
+				"prefix not preserved: desc=%q got=%q", desc, got)
 		}
 	})
 }
 
 // TestAppendConversionUnavailableDescriptionInvariants: contains marker and currencies.
 func TestAppendConversionUnavailableDescriptionInvariants(t *testing.T) {
+	t.Parallel()
 	rapid.Check(t, func(t *rapid.T) {
 		desc := rapid.StringMatching(`[A-Za-z ]{0,20}`).Draw(t, "desc")
 		origCur := rapid.StringMatching(`[A-Z]{3}`).Draw(t, "origCur")
@@ -126,21 +113,13 @@ func TestAppendConversionUnavailableDescriptionInvariants(t *testing.T) {
 
 		got := appendConversionUnavailableDescription(desc, origCur, targetCur)
 
-		if !strings.Contains(got, "fx_unavailable") {
-			t.Fatalf("missing fx_unavailable marker: %q", got)
-		}
-		if !strings.Contains(got, origCur) {
-			t.Fatalf("missing origCur %q: %q", origCur, got)
-		}
-		if !strings.Contains(got, targetCur) {
-			t.Fatalf("missing targetCur %q: %q", targetCur, got)
-		}
+		require.Contains(t, got, "fx_unavailable")
+		require.Contains(t, got, origCur)
+		require.Contains(t, got, targetCur)
 
-		trimmed := strings.TrimSpace(desc)
-		if trimmed != "" {
-			if !strings.HasPrefix(got, desc+" ") {
-				t.Fatalf("prefix not preserved: desc=%q got=%q", desc, got)
-			}
+		if strings.TrimSpace(desc) != "" {
+			require.True(t, strings.HasPrefix(got, desc+" "),
+				"prefix not preserved: desc=%q got=%q", desc, got)
 		}
 	})
 }

--- a/internal/bot/date_range_rapid_test.go
+++ b/internal/bot/date_range_rapid_test.go
@@ -1,0 +1,120 @@
+package bot
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+)
+
+// genLocation draws a fixed offset location between -12h and +14h.
+func genLocation() *rapid.Generator[*time.Location] {
+	return rapid.Custom(func(t *rapid.T) *time.Location {
+		hours := rapid.IntRange(-12, 14).Draw(t, "hours")
+		return time.FixedZone("gen", hours*3600)
+	})
+}
+
+// genTimeInLocation generates a time within 2000..2040 attached to a drawn location.
+func genTimeInLocation() *rapid.Generator[time.Time] {
+	return rapid.Custom(func(t *rapid.T) time.Time {
+		loc := genLocation().Draw(t, "loc")
+		year := rapid.IntRange(2000, 2040).Draw(t, "year")
+		month := rapid.IntRange(1, 12).Draw(t, "month")
+		day := rapid.IntRange(1, 28).Draw(t, "day")
+		hour := rapid.IntRange(0, 23).Draw(t, "hour")
+		minute := rapid.IntRange(0, 59).Draw(t, "minute")
+		second := rapid.IntRange(0, 59).Draw(t, "second")
+		return time.Date(year, time.Month(month), day, hour, minute, second, 0, loc)
+	})
+}
+
+// TestNormalizeLocationNilReturnsLocal: nil → time.Local.
+func TestNormalizeLocationNilReturnsLocal(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, time.Local, normalizeLocation(nil)) //nolint:gosmopolitan // mirrors prod fallback
+}
+
+// TestNormalizeLocationNonNilPassthrough: non-nil input returned verbatim.
+func TestNormalizeLocationNonNilPassthrough(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(t *rapid.T) {
+		loc := genLocation().Draw(t, "loc")
+		require.Same(t, loc, normalizeLocation(loc))
+	})
+}
+
+// TestGetDayDateRangeAtInvariants:
+//   - start is 00:00:00 on current's calendar date
+//   - end == start.AddDate(0,0,1)
+//   - start <= current < end
+//   - both in same location
+func TestGetDayDateRangeAtInvariants(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(t *rapid.T) {
+		cur := genTimeInLocation().Draw(t, "cur")
+		start, end := getDayDateRangeAt(cur)
+
+		require.Equal(t, 0, start.Hour())
+		require.Equal(t, 0, start.Minute())
+		require.Equal(t, 0, start.Second())
+		require.Equal(t, 0, start.Nanosecond())
+		require.Equal(t, cur.Year(), start.Year())
+		require.Equal(t, cur.Month(), start.Month())
+		require.Equal(t, cur.Day(), start.Day())
+		require.Equal(t, start.AddDate(0, 0, 1), end)
+		require.False(t, cur.Before(start), "cur before start")
+		require.True(t, cur.Before(end), "cur not before end")
+		require.Equal(t, cur.Location(), start.Location())
+		require.Equal(t, cur.Location(), end.Location())
+	})
+}
+
+// TestGetWeekDateRangeAtInvariants:
+//   - start.Weekday() == Monday
+//   - end == start.AddDate(0,0,7)
+//   - start <= current < end
+//   - start at midnight
+func TestGetWeekDateRangeAtInvariants(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(t *rapid.T) {
+		cur := genTimeInLocation().Draw(t, "cur")
+		start, end := getWeekDateRangeAt(cur)
+
+		require.Equal(t, time.Monday, start.Weekday(), "start=%s", start)
+		require.Equal(t, start.AddDate(0, 0, 7), end)
+		require.Equal(t, 0, start.Hour())
+		require.Equal(t, 0, start.Minute())
+		require.Equal(t, 0, start.Second())
+		require.Equal(t, 0, start.Nanosecond())
+		require.False(t, cur.Before(start), "cur=%s start=%s", cur, start)
+		require.True(t, cur.Before(end), "cur=%s end=%s", cur, end)
+		require.Equal(t, cur.Location(), start.Location())
+	})
+}
+
+// TestGetMonthDateRangeAtInvariants:
+//   - start.Day() == 1
+//   - start at midnight
+//   - end == start.AddDate(0,1,0)
+//   - start <= current < end
+func TestGetMonthDateRangeAtInvariants(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(t *rapid.T) {
+		cur := genTimeInLocation().Draw(t, "cur")
+		start, end := getMonthDateRangeAt(cur)
+
+		require.Equal(t, 1, start.Day())
+		require.Equal(t, 0, start.Hour())
+		require.Equal(t, 0, start.Minute())
+		require.Equal(t, 0, start.Second())
+		require.Equal(t, 0, start.Nanosecond())
+		require.Equal(t, cur.Year(), start.Year())
+		require.Equal(t, cur.Month(), start.Month())
+		require.Equal(t, start.AddDate(0, 1, 0), end)
+		require.False(t, cur.Before(start))
+		require.True(t, cur.Before(end))
+		require.Equal(t, cur.Location(), start.Location())
+	})
+}

--- a/internal/bot/extract_command_args_rapid_test.go
+++ b/internal/bot/extract_command_args_rapid_test.go
@@ -1,0 +1,95 @@
+package bot
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+)
+
+// genCommand generates a slash command name like "/add", "/list".
+func genCommand() *rapid.Generator[string] {
+	return rapid.Custom(func(t *rapid.T) string {
+		name := rapid.StringMatching(`[a-z]{1,15}`).Draw(t, "name")
+		return "/" + name
+	})
+}
+
+// genBotName generates a @botname suffix like "@myBot".
+func genBotName() *rapid.Generator[string] {
+	return rapid.StringMatching(`@[A-Za-z0-9_]{1,20}`)
+}
+
+// genArgs generates a free-text argument string without the '@' and '/' sentinels
+// that extractCommandArgs treats specially.
+func genArgs() *rapid.Generator[string] {
+	return rapid.StringMatching(`[A-Za-z0-9 .,]{0,30}`)
+}
+
+// TestExtractCommandArgsPlain: "/cmd ARGS" → trimmed ARGS.
+func TestExtractCommandArgsPlain(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(t *rapid.T) {
+		cmd := genCommand().Draw(t, "cmd")
+		args := genArgs().Draw(t, "args")
+		input := cmd + " " + args
+
+		got := extractCommandArgs(input, cmd)
+		require.Equal(t, strings.TrimSpace(args), got, "input=%q", input)
+	})
+}
+
+// TestExtractCommandArgsWithBotMention: "/cmd@bot ARGS" → trimmed ARGS.
+func TestExtractCommandArgsWithBotMention(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(t *rapid.T) {
+		cmd := genCommand().Draw(t, "cmd")
+		bot := genBotName().Draw(t, "bot")
+		args := genArgs().Draw(t, "args")
+		input := cmd + bot + " " + args
+
+		got := extractCommandArgs(input, cmd)
+		require.Equal(t, strings.TrimSpace(args), got, "input=%q", input)
+	})
+}
+
+// TestExtractCommandArgsBotOnly: "/cmd@bot" (no args) → "".
+func TestExtractCommandArgsBotOnly(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(t *rapid.T) {
+		cmd := genCommand().Draw(t, "cmd")
+		bot := genBotName().Draw(t, "bot")
+		input := cmd + bot
+
+		got := extractCommandArgs(input, cmd)
+		require.Empty(t, got, "input=%q", input)
+	})
+}
+
+// TestExtractCommandArgsNoArgs: "/cmd" alone → "".
+func TestExtractCommandArgsNoArgs(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(t *rapid.T) {
+		cmd := genCommand().Draw(t, "cmd")
+		got := extractCommandArgs(cmd, cmd)
+		require.Empty(t, got)
+	})
+}
+
+// TestExtractCommandArgsNeverLeadingAtOrWhitespace: after a single optional
+// "@botname" suffix, result never starts with '@' and is trimmed.
+// Tails excluding '@' cover the "no further @mentions after the bot suffix"
+// case since extractCommandArgs only strips the first "@..." segment.
+func TestExtractCommandArgsNeverLeadingAtOrWhitespace(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(t *rapid.T) {
+		cmd := genCommand().Draw(t, "cmd")
+		tail := rapid.StringMatching(`[A-Za-z0-9 _.,]{0,30}`).Draw(t, "tail")
+		input := cmd + tail
+
+		got := extractCommandArgs(input, cmd)
+		require.False(t, strings.HasPrefix(got, "@"), "leading @: got=%q input=%q", got, input)
+		require.Equal(t, strings.TrimSpace(got), got, "not trimmed: %q", got)
+	})
+}

--- a/internal/bot/parse_tag_command_rapid_test.go
+++ b/internal/bot/parse_tag_command_rapid_test.go
@@ -1,0 +1,76 @@
+package bot
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+)
+
+// TestParseTagCommandValidInputsRoundTrip: well-formed "/tag <id> #tag1 #tag2..."
+// returns the id, the tag slice verbatim, and an empty error message.
+func TestParseTagCommandValidInputsRoundTrip(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(t *rapid.T) {
+		id := rapid.Int64Range(1, 1_000_000).Draw(t, "id")
+		n := rapid.IntRange(1, 5).Draw(t, "n")
+		tags := make([]string, n)
+		for i := range n {
+			name := rapid.StringMatching(`[A-Za-z][A-Za-z0-9_]{0,9}`).Draw(t, "tag")
+			tags[i] = "#" + name
+		}
+		text := "/tag " + strconv.FormatInt(id, 10) + " " + strings.Join(tags, " ")
+
+		gotID, gotTags, gotErr := parseTagCommand(text)
+		require.Empty(t, gotErr, "text=%q", text)
+		require.Equal(t, id, gotID)
+		require.Equal(t, tags, gotTags)
+	})
+}
+
+// TestParseTagCommandMissingArgsErrors: "/tag" alone or with whitespace only
+// returns an error message and zero id.
+func TestParseTagCommandMissingArgsErrors(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(t *rapid.T) {
+		pad := rapid.StringMatching(`[ \t]*`).Draw(t, "pad")
+		text := "/tag" + pad
+
+		gotID, gotTags, gotErr := parseTagCommand(text)
+		require.Zero(t, gotID)
+		require.Nil(t, gotTags)
+		require.NotEmpty(t, gotErr)
+	})
+}
+
+// TestParseTagCommandMissingTagsErrors: "/tag <id>" without any tag tokens
+// returns an error and zero id.
+func TestParseTagCommandMissingTagsErrors(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(t *rapid.T) {
+		id := rapid.Int64Range(1, 1_000_000).Draw(t, "id")
+		text := "/tag " + strconv.FormatInt(id, 10)
+
+		gotID, gotTags, gotErr := parseTagCommand(text)
+		require.Zero(t, gotID)
+		require.Nil(t, gotTags)
+		require.NotEmpty(t, gotErr)
+	})
+}
+
+// TestParseTagCommandInvalidIDErrors: first arg not an int64 → error, zero id.
+func TestParseTagCommandInvalidIDErrors(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(t *rapid.T) {
+		// non-numeric first token; require at least one non-digit char
+		garbage := rapid.StringMatching(`[A-Za-z]{1,8}`).Draw(t, "garbage")
+		text := "/tag " + garbage + " #foo"
+
+		gotID, gotTags, gotErr := parseTagCommand(text)
+		require.Zero(t, gotID)
+		require.Nil(t, gotTags)
+		require.NotEmpty(t, gotErr)
+	})
+}

--- a/internal/bot/parser_rapid_test.go
+++ b/internal/bot/parser_rapid_test.go
@@ -1,10 +1,12 @@
 package bot
 
 import (
+	"sort"
 	"strings"
 	"testing"
 
 	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/require"
 	"gitlab.com/yelinaung/expense-bot/internal/models"
 	"pgregory.net/rapid"
 )
@@ -46,42 +48,37 @@ func genDescription() *rapid.Generator[string] {
 }
 
 // genSupportedCurrencyCode draws a code from models.SupportedCurrencies.
+// Codes are sorted for deterministic rapid seeding across runs.
 func genSupportedCurrencyCode() *rapid.Generator[string] {
 	codes := make([]string, 0, len(models.SupportedCurrencies))
 	for c := range models.SupportedCurrencies {
 		codes = append(codes, c)
 	}
+	sort.Strings(codes)
 	return rapid.SampledFrom(codes)
 }
 
 // TestParseAmountAcceptsPositiveDecimals: parseAmount accepts positive decimal strings.
 func TestParseAmountAcceptsPositiveDecimals(t *testing.T) {
+	t.Parallel()
 	rapid.Check(t, func(t *rapid.T) {
 		s := genPositiveAmountString().Draw(t, "amountStr")
 		amt, err := parseAmount(s)
-		if err != nil {
-			t.Fatalf("parseAmount(%q) err: %v", s, err)
-		}
-		if !amt.GreaterThan(decimal.Zero) {
-			t.Fatalf("parseAmount(%q) = %s, want > 0", s, amt)
-		}
+		require.NoError(t, err, "parseAmount(%q)", s)
+		require.True(t, amt.GreaterThan(decimal.Zero), "parseAmount(%q) = %s", s, amt)
 
-		// Comma variant parses to same value.
 		if strings.Contains(s, ".") {
 			commaStr := strings.ReplaceAll(s, ".", ",")
 			amt2, err2 := parseAmount(commaStr)
-			if err2 != nil {
-				t.Fatalf("parseAmount(%q) err: %v", commaStr, err2)
-			}
-			if !amt.Equal(amt2) {
-				t.Fatalf("comma variant mismatch: %s vs %s", amt, amt2)
-			}
+			require.NoError(t, err2, "parseAmount(%q)", commaStr)
+			require.True(t, amt.Equal(amt2), "comma variant mismatch: %s vs %s", amt, amt2)
 		}
 	})
 }
 
 // TestParseAmountRejectsNonPositive: parseAmount rejects zero or negative.
 func TestParseAmountRejectsNonPositive(t *testing.T) {
+	t.Parallel()
 	rapid.Check(t, func(t *rapid.T) {
 		n := rapid.IntRange(0, 1_000_000).Draw(t, "n")
 		frac := rapid.IntRange(0, 99).Draw(t, "frac")
@@ -93,14 +90,13 @@ func TestParseAmountRejectsNonPositive(t *testing.T) {
 			t.Skip("positive — covered in other test")
 		}
 		_, err := parseAmount(d.String())
-		if err == nil {
-			t.Fatalf("parseAmount(%q) expected error", d.String())
-		}
+		require.Error(t, err, "parseAmount(%q) expected error", d.String())
 	})
 }
 
 // TestExtractTagsIdempotent: second extraction from cleaned text yields no tags.
 func TestExtractTagsIdempotent(t *testing.T) {
+	t.Parallel()
 	rapid.Check(t, func(t *rapid.T) {
 		n := rapid.IntRange(0, 5).Draw(t, "n")
 		parts := make([]string, 0, 1+n)
@@ -113,58 +109,43 @@ func TestExtractTagsIdempotent(t *testing.T) {
 
 		tags, cleaned := extractTags(input)
 
-		// All tags lowercased.
 		for _, tag := range tags {
-			if tag != strings.ToLower(tag) {
-				t.Fatalf("tag not lowercased: %q", tag)
-			}
+			require.Equal(t, strings.ToLower(tag), tag, "tag not lowercased: %q", tag)
 		}
 
-		// Tags are deduplicated.
 		seen := map[string]bool{}
 		for _, tag := range tags {
-			if seen[tag] {
-				t.Fatalf("duplicate tag: %q", tag)
-			}
+			require.False(t, seen[tag], "duplicate tag: %q", tag)
 			seen[tag] = true
 		}
 
-		// Idempotence: cleaned text has no more tags to extract.
 		tags2, _ := extractTags(cleaned)
-		if len(tags2) != 0 {
-			t.Fatalf("cleaned text still has tags: %v (cleaned=%q)", tags2, cleaned)
-		}
+		require.Empty(t, tags2, "cleaned text still has tags (cleaned=%q)", cleaned)
 	})
 }
 
 // TestParseExpenseInputAmountFirst: "AMOUNT DESCRIPTION" parses with matching amount + desc.
 func TestParseExpenseInputAmountFirst(t *testing.T) {
+	t.Parallel()
 	rapid.Check(t, func(t *rapid.T) {
 		amtStr := genPositiveAmountString().Draw(t, "amount")
 		desc := genDescription().Draw(t, "desc")
 		input := amtStr + " " + desc
 
 		parsed := ParseExpenseInput(input)
-		if parsed == nil {
-			t.Fatalf("ParseExpenseInput(%q) = nil", input)
-			return
-		}
+		require.NotNil(t, parsed, "ParseExpenseInput(%q)", input)
 
 		wantAmt, err := decimal.NewFromString(amtStr)
-		if err != nil {
-			t.Fatalf("bad amount: %v", err)
-		}
-		if !parsed.Amount.Equal(wantAmt) {
-			t.Fatalf("amount mismatch: got %s, want %s (input=%q)", parsed.Amount, wantAmt, input)
-		}
-		if parsed.Description != desc {
-			t.Fatalf("desc mismatch: got %q, want %q (input=%q)", parsed.Description, desc, input)
-		}
+		require.NoError(t, err)
+		require.True(t, parsed.Amount.Equal(wantAmt),
+			"amount mismatch: got %s, want %s (input=%q)", parsed.Amount, wantAmt, input)
+		require.Equal(t, desc, parsed.Description, "input=%q", input)
 	})
 }
 
 // TestParseExpenseInputWithCurrencyPrefix: "CODE AMOUNT DESC" detects currency.
 func TestParseExpenseInputWithCurrencyPrefix(t *testing.T) {
+	t.Parallel()
 	rapid.Check(t, func(t *rapid.T) {
 		code := genSupportedCurrencyCode().Draw(t, "code")
 		amtStr := genPositiveAmountString().Draw(t, "amount")
@@ -172,26 +153,19 @@ func TestParseExpenseInputWithCurrencyPrefix(t *testing.T) {
 		input := code + " " + amtStr + " " + desc
 
 		parsed := ParseExpenseInput(input)
-		if parsed == nil {
-			t.Fatalf("ParseExpenseInput(%q) = nil", input)
-			return
-		}
-		// USD via leading "$" symbol is ambiguous and intentionally cleared,
-		// but leading currency CODE (e.g., "USD") stays set. Check code path.
-		if parsed.Currency != code {
-			t.Fatalf("currency mismatch: got %q, want %q (input=%q)", parsed.Currency, code, input)
-		}
+		require.NotNil(t, parsed, "ParseExpenseInput(%q)", input)
+		// Leading CODE (e.g., "USD") stays set; leading "$" symbol is intentionally cleared.
+		require.Equal(t, code, parsed.Currency, "input=%q", input)
 	})
 }
 
 // TestContainsDigitMatchesStrings: containsDigit equals stdlib behavior.
 func TestContainsDigitMatchesStrings(t *testing.T) {
+	t.Parallel()
 	rapid.Check(t, func(t *rapid.T) {
 		s := rapid.String().Draw(t, "s")
 		got := containsDigit(s)
 		want := strings.ContainsAny(s, "0123456789")
-		if got != want {
-			t.Fatalf("containsDigit(%q) = %v, want %v", s, got, want)
-		}
+		require.Equal(t, want, got, "containsDigit(%q)", s)
 	})
 }

--- a/internal/bot/parser_rapid_test.go
+++ b/internal/bot/parser_rapid_test.go
@@ -1,7 +1,6 @@
 package bot
 
 import (
-	"sort"
 	"strings"
 	"testing"
 
@@ -57,17 +56,6 @@ func genDescription() *rapid.Generator[string] {
 		}
 		return strings.Join(words, " ")
 	})
-}
-
-// genSupportedCurrencyCode draws a code from models.SupportedCurrencies.
-// Codes are sorted for deterministic rapid seeding across runs.
-func genSupportedCurrencyCode() *rapid.Generator[string] {
-	codes := make([]string, 0, len(models.SupportedCurrencies))
-	for c := range models.SupportedCurrencies {
-		codes = append(codes, c)
-	}
-	sort.Strings(codes)
-	return rapid.SampledFrom(codes)
 }
 
 // TestParseAmountAcceptsPositiveDecimals: parseAmount accepts positive decimal strings.
@@ -159,7 +147,7 @@ func TestParseExpenseInputAmountFirst(t *testing.T) {
 func TestParseExpenseInputWithCurrencyPrefix(t *testing.T) {
 	t.Parallel()
 	rapid.Check(t, func(t *rapid.T) {
-		code := genSupportedCurrencyCode().Draw(t, "code")
+		code := genSupportedCurrency().Draw(t, "code")
 		amtStr := genPositiveAmountString().Draw(t, "amount")
 		desc := genDescription().Draw(t, "desc")
 		input := code + " " + amtStr + " " + desc

--- a/internal/bot/parser_rapid_test.go
+++ b/internal/bot/parser_rapid_test.go
@@ -103,7 +103,8 @@ func TestParseAmountRejectsNonPositive(t *testing.T) {
 func TestExtractTagsIdempotent(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		n := rapid.IntRange(0, 5).Draw(t, "n")
-		parts := []string{"lunch"}
+		parts := make([]string, 0, 1+n)
+		parts = append(parts, "lunch")
 		for range n {
 			tag := rapid.StringMatching(`[a-z]{1,10}`).Draw(t, "tag")
 			parts = append(parts, "#"+tag)
@@ -146,6 +147,7 @@ func TestParseExpenseInputAmountFirst(t *testing.T) {
 		parsed := ParseExpenseInput(input)
 		if parsed == nil {
 			t.Fatalf("ParseExpenseInput(%q) = nil", input)
+			return
 		}
 
 		wantAmt, err := decimal.NewFromString(amtStr)
@@ -172,6 +174,7 @@ func TestParseExpenseInputWithCurrencyPrefix(t *testing.T) {
 		parsed := ParseExpenseInput(input)
 		if parsed == nil {
 			t.Fatalf("ParseExpenseInput(%q) = nil", input)
+			return
 		}
 		// USD via leading "$" symbol is ambiguous and intentionally cleared,
 		// but leading currency CODE (e.g., "USD") stays set. Check code path.

--- a/internal/bot/parser_rapid_test.go
+++ b/internal/bot/parser_rapid_test.go
@@ -143,6 +143,42 @@ func TestParseExpenseInputAmountFirst(t *testing.T) {
 	})
 }
 
+// TestParseExpenseInputNoAmount: pure letters/spaces with no numeric token
+// must not parse. Both the leading-amount and reordered-amount paths require
+// a parseable amount, so the result is nil.
+func TestParseExpenseInputNoAmount(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(t *rapid.T) {
+		desc := genDescription().Draw(t, "desc")
+		parsed := ParseExpenseInput(desc)
+		require.Nil(t, parsed, "ParseExpenseInput(%q)", desc)
+	})
+}
+
+// TestParseExpenseInputWhitespaceTolerantAmount: leading/trailing/extra inner
+// spaces around "AMOUNT DESC" don't change the parsed amount. Description is
+// not compared because parser may normalize whitespace inside the description.
+func TestParseExpenseInputWhitespaceTolerantAmount(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(t *rapid.T) {
+		amtStr := genPositiveAmountString().Draw(t, "amount")
+		desc := genDescription().Draw(t, "desc")
+		lead := rapid.StringMatching(`[ \t]{0,4}`).Draw(t, "lead")
+		trail := rapid.StringMatching(`[ \t]{0,4}`).Draw(t, "trail")
+		gap := rapid.StringMatching(`[ \t]{1,4}`).Draw(t, "gap")
+		base := amtStr + " " + desc
+		noisy := lead + amtStr + gap + desc + trail
+
+		parsedBase := ParseExpenseInput(base)
+		parsedNoisy := ParseExpenseInput(noisy)
+		require.NotNil(t, parsedBase, "base=%q", base)
+		require.NotNil(t, parsedNoisy, "noisy=%q", noisy)
+		require.True(t, parsedBase.Amount.Equal(parsedNoisy.Amount),
+			"amount mismatch: base=%s noisy=%s (base=%q noisy=%q)",
+			parsedBase.Amount, parsedNoisy.Amount, base, noisy)
+	})
+}
+
 // TestParseExpenseInputWithCurrencyPrefix: "CODE AMOUNT DESC" detects currency.
 func TestParseExpenseInputWithCurrencyPrefix(t *testing.T) {
 	t.Parallel()

--- a/internal/bot/parser_rapid_test.go
+++ b/internal/bot/parser_rapid_test.go
@@ -1,0 +1,194 @@
+package bot
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/shopspring/decimal"
+	"gitlab.com/yelinaung/expense-bot/internal/models"
+	"pgregory.net/rapid"
+)
+
+// genPositiveAmountString generates a positive decimal string with up to 2 fractional digits.
+func genPositiveAmountString() *rapid.Generator[string] {
+	return rapid.Custom(func(t *rapid.T) string {
+		whole := rapid.IntRange(0, 1_000_000).Draw(t, "whole")
+		frac := rapid.IntRange(0, 99).Draw(t, "frac")
+		hasFrac := rapid.Bool().Draw(t, "hasFrac")
+		if !hasFrac {
+			if whole == 0 {
+				whole = 1
+			}
+			return decimal.NewFromInt(int64(whole)).String()
+		}
+		if whole == 0 && frac == 0 {
+			frac = 1
+		}
+		return decimal.New(int64(whole*100+frac), -2).String()
+	})
+}
+
+// genDescWord generates a single lowercase word with no digits / tag / bracket markers.
+func genDescWord() *rapid.Generator[string] {
+	return rapid.StringMatching(`[a-z]{1,10}`)
+}
+
+// genDescription generates a description of 1..4 words, no digits, no special chars.
+func genDescription() *rapid.Generator[string] {
+	return rapid.Custom(func(t *rapid.T) string {
+		n := rapid.IntRange(1, 4).Draw(t, "n")
+		words := make([]string, n)
+		for i := range n {
+			words[i] = genDescWord().Draw(t, "word")
+		}
+		return strings.Join(words, " ")
+	})
+}
+
+// genSupportedCurrencyCode draws a code from models.SupportedCurrencies.
+func genSupportedCurrencyCode() *rapid.Generator[string] {
+	codes := make([]string, 0, len(models.SupportedCurrencies))
+	for c := range models.SupportedCurrencies {
+		codes = append(codes, c)
+	}
+	return rapid.SampledFrom(codes)
+}
+
+// TestParseAmountAcceptsPositiveDecimals: parseAmount accepts positive decimal strings.
+func TestParseAmountAcceptsPositiveDecimals(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		s := genPositiveAmountString().Draw(t, "amountStr")
+		amt, err := parseAmount(s)
+		if err != nil {
+			t.Fatalf("parseAmount(%q) err: %v", s, err)
+		}
+		if !amt.GreaterThan(decimal.Zero) {
+			t.Fatalf("parseAmount(%q) = %s, want > 0", s, amt)
+		}
+
+		// Comma variant parses to same value.
+		if strings.Contains(s, ".") {
+			commaStr := strings.ReplaceAll(s, ".", ",")
+			amt2, err2 := parseAmount(commaStr)
+			if err2 != nil {
+				t.Fatalf("parseAmount(%q) err: %v", commaStr, err2)
+			}
+			if !amt.Equal(amt2) {
+				t.Fatalf("comma variant mismatch: %s vs %s", amt, amt2)
+			}
+		}
+	})
+}
+
+// TestParseAmountRejectsNonPositive: parseAmount rejects zero or negative.
+func TestParseAmountRejectsNonPositive(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		n := rapid.IntRange(0, 1_000_000).Draw(t, "n")
+		frac := rapid.IntRange(0, 99).Draw(t, "frac")
+		negative := rapid.Bool().Draw(t, "neg")
+		d := decimal.New(int64(n*100+frac), -2)
+		if negative {
+			d = d.Neg()
+		} else if d.IsPositive() {
+			t.Skip("positive — covered in other test")
+		}
+		_, err := parseAmount(d.String())
+		if err == nil {
+			t.Fatalf("parseAmount(%q) expected error", d.String())
+		}
+	})
+}
+
+// TestExtractTagsIdempotent: second extraction from cleaned text yields no tags.
+func TestExtractTagsIdempotent(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		n := rapid.IntRange(0, 5).Draw(t, "n")
+		parts := []string{"lunch"}
+		for range n {
+			tag := rapid.StringMatching(`[a-z]{1,10}`).Draw(t, "tag")
+			parts = append(parts, "#"+tag)
+		}
+		input := strings.Join(parts, " ")
+
+		tags, cleaned := extractTags(input)
+
+		// All tags lowercased.
+		for _, tag := range tags {
+			if tag != strings.ToLower(tag) {
+				t.Fatalf("tag not lowercased: %q", tag)
+			}
+		}
+
+		// Tags are deduplicated.
+		seen := map[string]bool{}
+		for _, tag := range tags {
+			if seen[tag] {
+				t.Fatalf("duplicate tag: %q", tag)
+			}
+			seen[tag] = true
+		}
+
+		// Idempotence: cleaned text has no more tags to extract.
+		tags2, _ := extractTags(cleaned)
+		if len(tags2) != 0 {
+			t.Fatalf("cleaned text still has tags: %v (cleaned=%q)", tags2, cleaned)
+		}
+	})
+}
+
+// TestParseExpenseInputAmountFirst: "AMOUNT DESCRIPTION" parses with matching amount + desc.
+func TestParseExpenseInputAmountFirst(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		amtStr := genPositiveAmountString().Draw(t, "amount")
+		desc := genDescription().Draw(t, "desc")
+		input := amtStr + " " + desc
+
+		parsed := ParseExpenseInput(input)
+		if parsed == nil {
+			t.Fatalf("ParseExpenseInput(%q) = nil", input)
+		}
+
+		wantAmt, err := decimal.NewFromString(amtStr)
+		if err != nil {
+			t.Fatalf("bad amount: %v", err)
+		}
+		if !parsed.Amount.Equal(wantAmt) {
+			t.Fatalf("amount mismatch: got %s, want %s (input=%q)", parsed.Amount, wantAmt, input)
+		}
+		if parsed.Description != desc {
+			t.Fatalf("desc mismatch: got %q, want %q (input=%q)", parsed.Description, desc, input)
+		}
+	})
+}
+
+// TestParseExpenseInputWithCurrencyPrefix: "CODE AMOUNT DESC" detects currency.
+func TestParseExpenseInputWithCurrencyPrefix(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		code := genSupportedCurrencyCode().Draw(t, "code")
+		amtStr := genPositiveAmountString().Draw(t, "amount")
+		desc := genDescription().Draw(t, "desc")
+		input := code + " " + amtStr + " " + desc
+
+		parsed := ParseExpenseInput(input)
+		if parsed == nil {
+			t.Fatalf("ParseExpenseInput(%q) = nil", input)
+		}
+		// USD via leading "$" symbol is ambiguous and intentionally cleared,
+		// but leading currency CODE (e.g., "USD") stays set. Check code path.
+		if parsed.Currency != code {
+			t.Fatalf("currency mismatch: got %q, want %q (input=%q)", parsed.Currency, code, input)
+		}
+	})
+}
+
+// TestContainsDigitMatchesStrings: containsDigit equals stdlib behavior.
+func TestContainsDigitMatchesStrings(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		s := rapid.String().Draw(t, "s")
+		got := containsDigit(s)
+		want := strings.ContainsAny(s, "0123456789")
+		if got != want {
+			t.Fatalf("containsDigit(%q) = %v, want %v", s, got, want)
+		}
+	})
+}

--- a/internal/bot/parser_rapid_test.go
+++ b/internal/bot/parser_rapid_test.go
@@ -31,8 +31,20 @@ func genPositiveAmountString() *rapid.Generator[string] {
 }
 
 // genDescWord generates a single lowercase word with no digits / tag / bracket markers.
+// Filters out words that collide with currency codes (e.g. "usd") or currency
+// words (e.g. "baht") since the parser would extract those as the currency and
+// shrink the description, breaking downstream assertions.
 func genDescWord() *rapid.Generator[string] {
-	return rapid.StringMatching(`[a-z]{1,10}`)
+	return rapid.StringMatching(`[a-z]{1,10}`).Filter(func(w string) bool {
+		u := strings.ToUpper(w)
+		if _, ok := models.SupportedCurrencies[u]; ok {
+			return false
+		}
+		if _, ok := currencyWordToCode[u]; ok {
+			return false
+		}
+		return true
+	})
 }
 
 // genDescription generates a description of 1..4 words, no digits, no special chars.
@@ -102,7 +114,7 @@ func TestExtractTagsIdempotent(t *testing.T) {
 		parts := make([]string, 0, 1+n)
 		parts = append(parts, "lunch")
 		for range n {
-			tag := rapid.StringMatching(`[a-z]{1,10}`).Draw(t, "tag")
+			tag := rapid.StringMatching(`[A-Za-z]{1,10}`).Draw(t, "tag")
 			parts = append(parts, "#"+tag)
 		}
 		input := strings.Join(parts, " ")

--- a/internal/bot/rapid_helpers_test.go
+++ b/internal/bot/rapid_helpers_test.go
@@ -1,0 +1,26 @@
+package bot
+
+import (
+	"sort"
+	"sync"
+
+	"gitlab.com/yelinaung/expense-bot/internal/models"
+	"pgregory.net/rapid"
+)
+
+// sortedSupportedCurrencyCodes returns models.SupportedCurrencies keys sorted
+// once. Caching keeps rapid.Check loops from rebuilding the slice per iteration
+// while preserving deterministic order across runs.
+var sortedSupportedCurrencyCodes = sync.OnceValue(func() []string {
+	codes := make([]string, 0, len(models.SupportedCurrencies))
+	for c := range models.SupportedCurrencies {
+		codes = append(codes, c)
+	}
+	sort.Strings(codes)
+	return codes
+})
+
+// genSupportedCurrency draws a currency code from models.SupportedCurrencies.
+func genSupportedCurrency() *rapid.Generator[string] {
+	return rapid.SampledFrom(sortedSupportedCurrencyCodes())
+}

--- a/internal/bot/reminder_rapid_test.go
+++ b/internal/bot/reminder_rapid_test.go
@@ -1,0 +1,72 @@
+package bot
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/require"
+	appmodels "gitlab.com/yelinaung/expense-bot/internal/models"
+	"pgregory.net/rapid"
+)
+
+// genExpense draws an Expense with a bounded positive amount.
+func genExpense() *rapid.Generator[appmodels.Expense] {
+	return rapid.Custom(func(t *rapid.T) appmodels.Expense {
+		v := rapid.IntRange(0, 1_000_000).Draw(t, "v")
+		exp := rapid.IntRange(-4, 2).Draw(t, "exp")
+		return appmodels.Expense{Amount: decimal.New(int64(v), int32(exp))}
+	})
+}
+
+// TestSumExpenseAmountsEmptyIsZero: sum of empty or nil slice is zero.
+func TestSumExpenseAmountsEmptyIsZero(t *testing.T) {
+	t.Parallel()
+	require.True(t, sumExpenseAmounts(nil).IsZero())
+	require.True(t, sumExpenseAmounts([]appmodels.Expense{}).IsZero())
+}
+
+// TestSumExpenseAmountsSingletonIdentity: sum of [x] equals x.
+func TestSumExpenseAmountsSingletonIdentity(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(t *rapid.T) {
+		e := genExpense().Draw(t, "e")
+		require.True(t, sumExpenseAmounts([]appmodels.Expense{e}).Equal(e.Amount))
+	})
+}
+
+// TestSumExpenseAmountsOrderInvariant: shuffling the slice doesn't change the sum.
+func TestSumExpenseAmountsOrderInvariant(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(t *rapid.T) {
+		n := rapid.IntRange(0, 12).Draw(t, "n")
+		xs := make([]appmodels.Expense, n)
+		for i := range n {
+			xs[i] = genExpense().Draw(t, "x")
+		}
+		seed := rapid.Int64().Draw(t, "seed")
+		ys := make([]appmodels.Expense, n)
+		copy(ys, xs)
+		// Deterministic shuffle driven by rapid-chosen seed for reproducibility.
+		r := rand.New(rand.NewSource(seed))
+		r.Shuffle(n, func(i, j int) { ys[i], ys[j] = ys[j], ys[i] })
+
+		require.True(t, sumExpenseAmounts(xs).Equal(sumExpenseAmounts(ys)))
+	})
+}
+
+// TestSumExpenseAmountsAssociativeSplit: sum(xs) == sum(xs[:k]) + sum(xs[k:]).
+func TestSumExpenseAmountsAssociativeSplit(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(t *rapid.T) {
+		n := rapid.IntRange(1, 12).Draw(t, "n")
+		xs := make([]appmodels.Expense, n)
+		for i := range n {
+			xs[i] = genExpense().Draw(t, "x")
+		}
+		k := rapid.IntRange(0, n).Draw(t, "k")
+		whole := sumExpenseAmounts(xs)
+		split := sumExpenseAmounts(xs[:k]).Add(sumExpenseAmounts(xs[k:]))
+		require.True(t, whole.Equal(split))
+	})
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -176,11 +176,11 @@ func parseInt64List(raw string) []int64 {
 func parseWhitelistedUsernames(raw string) []string {
 	var usernames []string
 	for username := range strings.SplitSeq(raw, ",") {
-		username = strings.TrimSpace(username)
+		username = strings.TrimPrefix(strings.TrimSpace(username), "@")
 		if username == "" {
 			continue
 		}
-		usernames = append(usernames, strings.TrimPrefix(username, "@"))
+		usernames = append(usernames, username)
 	}
 	return usernames
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -176,7 +176,7 @@ func parseInt64List(raw string) []int64 {
 func parseWhitelistedUsernames(raw string) []string {
 	var usernames []string
 	for username := range strings.SplitSeq(raw, ",") {
-		username = strings.TrimPrefix(strings.TrimSpace(username), "@")
+		username = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(username), "@"))
 		if username == "" {
 			continue
 		}

--- a/internal/config/config_rapid_test.go
+++ b/internal/config/config_rapid_test.go
@@ -9,11 +9,14 @@ import (
 	"pgregory.net/rapid"
 )
 
-// TestNormalizeUsernameIdempotent: norm(norm(x)) == norm(x).
+// TestNormalizeUsernameIdempotent: norm(norm(x)) == norm(x) over the contract
+// input shape (optional single '@' + username chars). normalizeUsername only
+// strips ONE leading '@' by design, so "@@A" -> "@a" -> "a" breaks idempotence;
+// that double-@ case is explicitly out of scope.
 func TestNormalizeUsernameIdempotent(t *testing.T) {
 	t.Parallel()
 	rapid.Check(t, func(t *rapid.T) {
-		s := rapid.String().Draw(t, "s")
+		s := rapid.StringMatching(`@?[A-Za-z0-9_]{0,20}`).Draw(t, "s")
 		once := normalizeUsername(s)
 		twice := normalizeUsername(once)
 		require.Equal(t, once, twice, "not idempotent (in=%q)", s)

--- a/internal/config/config_rapid_test.go
+++ b/internal/config/config_rapid_test.go
@@ -1,0 +1,127 @@
+package config
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+)
+
+// TestNormalizeUsernameIdempotent: norm(norm(x)) == norm(x).
+func TestNormalizeUsernameIdempotent(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(t *rapid.T) {
+		s := rapid.String().Draw(t, "s")
+		once := normalizeUsername(s)
+		twice := normalizeUsername(once)
+		require.Equal(t, once, twice, "not idempotent (in=%q)", s)
+	})
+}
+
+// TestNormalizeUsernameLowercaseNoLeadingAt:
+//   - output is lowercase
+//   - output has no leading "@" (one is stripped; more than one was not stripped
+//     by the original implementation, so this pins single-@ semantics)
+func TestNormalizeUsernameLowercaseNoLeadingAt(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(t *rapid.T) {
+		// Restrict to single-@ prefix forms; double-@ is not stripped by design.
+		prefix := rapid.SampledFrom([]string{"", "@"}).Draw(t, "prefix")
+		name := rapid.StringMatching(`[A-Za-z0-9_]{0,20}`).Draw(t, "name")
+		in := prefix + name
+		got := normalizeUsername(in)
+
+		require.Equal(t, strings.ToLower(got), got, "not lowercased: %q", got)
+		require.False(t, strings.HasPrefix(got, "@"), "leading @: %q", got)
+	})
+}
+
+// TestParseInt64ListSkipsInvalidAndEmpty: every element in the output is a
+// successfully parsed int64; non-numeric tokens are dropped.
+func TestParseInt64ListSkipsInvalidAndEmpty(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(t *rapid.T) {
+		n := rapid.IntRange(0, 8).Draw(t, "n")
+		parts := make([]string, n)
+		for i := range n {
+			// Mix of valid ints, garbage, whitespace-only.
+			switch rapid.IntRange(0, 2).Draw(t, "kind") {
+			case 0:
+				parts[i] = strconv.FormatInt(rapid.Int64().Draw(t, "n64"), 10)
+			case 1:
+				parts[i] = rapid.StringMatching(`[A-Za-z]{0,10}`).Draw(t, "junk")
+			default:
+				parts[i] = rapid.StringMatching(` {0,5}`).Draw(t, "ws")
+			}
+		}
+		raw := strings.Join(parts, ",")
+		got := parseInt64List(raw)
+
+		for _, id := range got {
+			// Round-trip: formatted output must parse back to the same int64.
+			s := strconv.FormatInt(id, 10)
+			parsed, err := strconv.ParseInt(s, 10, 64)
+			require.NoError(t, err)
+			require.Equal(t, id, parsed)
+		}
+		require.LessOrEqual(t, len(got), n)
+	})
+}
+
+// TestParseInt64ListOnlyValidInts: input composed solely of valid ints comma-joined
+// yields a slice of equal length and values.
+func TestParseInt64ListOnlyValidInts(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(t *rapid.T) {
+		n := rapid.IntRange(1, 8).Draw(t, "n")
+		want := make([]int64, n)
+		parts := make([]string, n)
+		for i := range n {
+			v := rapid.Int64().Draw(t, "v")
+			want[i] = v
+			parts[i] = strconv.FormatInt(v, 10)
+		}
+		got := parseInt64List(strings.Join(parts, ","))
+		require.Equal(t, want, got)
+	})
+}
+
+// TestParseWhitelistedUsernamesStripsAtAndTrims:
+//   - no entry is empty
+//   - no entry starts with '@'
+//   - no entry has leading/trailing whitespace
+func TestParseWhitelistedUsernamesStripsAtAndTrims(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(t *rapid.T) {
+		n := rapid.IntRange(0, 8).Draw(t, "n")
+		parts := make([]string, n)
+		for i := range n {
+			leadAt := rapid.Bool().Draw(t, "leadAt")
+			pad := rapid.StringMatching(` {0,3}`).Draw(t, "pad")
+			name := rapid.StringMatching(`[A-Za-z0-9_]{0,10}`).Draw(t, "name")
+			if leadAt {
+				parts[i] = pad + "@" + name + pad
+			} else {
+				parts[i] = pad + name + pad
+			}
+		}
+		raw := strings.Join(parts, ",")
+		got := parseWhitelistedUsernames(raw)
+
+		for _, u := range got {
+			require.NotEmpty(t, u, "empty entry slipped through")
+			require.False(t, strings.HasPrefix(u, "@"), "leading @: %q", u)
+			require.Equal(t, strings.TrimSpace(u), u, "not trimmed: %q", u)
+		}
+		require.LessOrEqual(t, len(got), n)
+	})
+}
+
+// TestParseWhitelistedUsernamesBareAtDropped: bare "@" tokens yield no entry.
+func TestParseWhitelistedUsernamesBareAtDropped(t *testing.T) {
+	t.Parallel()
+	require.Empty(t, parseWhitelistedUsernames("@"))
+	require.Empty(t, parseWhitelistedUsernames(" @ , @ "))
+}

--- a/internal/exchange/exchange_rapid_test.go
+++ b/internal/exchange/exchange_rapid_test.go
@@ -1,0 +1,115 @@
+package exchange
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+)
+
+// genPositiveDecimal produces a bounded strictly-positive decimal.
+func genPositiveDecimal() *rapid.Generator[decimal.Decimal] {
+	return rapid.Custom(func(t *rapid.T) decimal.Decimal {
+		v := rapid.IntRange(1, 1_000_000).Draw(t, "v")
+		exp := rapid.IntRange(-4, 2).Draw(t, "exp")
+		return decimal.New(int64(v), int32(exp))
+	})
+}
+
+// TestNormalizePairContainsArrow: output always contains the "->" separator.
+func TestNormalizePairContainsArrow(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(t *rapid.T) {
+		from := rapid.String().Draw(t, "from")
+		to := rapid.String().Draw(t, "to")
+		got := normalizePair(from, to)
+		require.Contains(t, got, "->")
+	})
+}
+
+// TestNormalizePairUppercase: both sides of "->" are uppercased and trimmed.
+func TestNormalizePairUppercase(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(t *rapid.T) {
+		from := rapid.String().Draw(t, "from")
+		to := rapid.String().Draw(t, "to")
+		got := normalizePair(from, to)
+		parts := strings.SplitN(got, "->", 2)
+		require.Len(t, parts, 2)
+		require.Equal(t, strings.ToUpper(parts[0]), parts[0])
+		require.Equal(t, strings.ToUpper(parts[1]), parts[1])
+		require.Equal(t, strings.TrimSpace(parts[0]), parts[0])
+		require.Equal(t, strings.TrimSpace(parts[1]), parts[1])
+	})
+}
+
+// TestNormalizePairIdempotentOnCleanInput: already-normalized currency codes
+// pass through unchanged when split back and renormalized.
+func TestNormalizePairIdempotentOnCleanInput(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(t *rapid.T) {
+		from := rapid.StringMatching(`[A-Z]{3}`).Draw(t, "from")
+		to := rapid.StringMatching(`[A-Z]{3}`).Draw(t, "to")
+		once := normalizePair(from, to)
+		parts := strings.SplitN(once, "->", 2)
+		twice := normalizePair(parts[0], parts[1])
+		require.Equal(t, once, twice)
+	})
+}
+
+// TestValidateConversionRatePositiveAccepts: any strictly-positive rate is accepted.
+func TestValidateConversionRatePositiveAccepts(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(t *rapid.T) {
+		rate := genPositiveDecimal().Draw(t, "rate")
+		require.NoError(t, validateConversionRate(rate))
+	})
+}
+
+// TestValidateConversionRateZeroOrNegativeRejects: zero and negative rates are rejected.
+func TestValidateConversionRateZeroOrNegativeRejects(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(t *rapid.T) {
+		v := rapid.IntRange(-1_000_000, 0).Draw(t, "v")
+		exp := rapid.IntRange(-4, 2).Draw(t, "exp")
+		rate := decimal.New(int64(v), int32(exp))
+		if rate.IsPositive() {
+			t.Skip("positive")
+		}
+		require.Error(t, validateConversionRate(rate))
+	})
+}
+
+// TestApplyCachedRatePreservesRateAndDate: rate + rateDate flow through unchanged.
+func TestApplyCachedRatePreservesRateAndDate(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(t *rapid.T) {
+		amount := genPositiveDecimal().Draw(t, "amount")
+		rate := genPositiveDecimal().Draw(t, "rate")
+		unix := rapid.Int64Range(0, 4_000_000_000).Draw(t, "unix")
+		entry := cachedRateEntry{
+			Rate:     rate,
+			RateDate: time.Unix(unix, 0).UTC(),
+		}
+		got := applyCachedRate(amount, entry)
+		require.True(t, got.Rate.Equal(rate))
+		require.Equal(t, entry.RateDate, got.RateDate)
+	})
+}
+
+// TestApplyCachedRateAmountRoundedTo2: output amount equals amount*rate rounded to 2 places.
+func TestApplyCachedRateAmountRoundedTo2(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(t *rapid.T) {
+		amount := genPositiveDecimal().Draw(t, "amount")
+		rate := genPositiveDecimal().Draw(t, "rate")
+		entry := cachedRateEntry{Rate: rate, RateDate: time.Unix(0, 0)}
+		got := applyCachedRate(amount, entry)
+		want := amount.Mul(rate).Round(2)
+		require.True(t, got.Amount.Equal(want),
+			"amount=%s rate=%s got=%s want=%s", amount, rate, got.Amount, want)
+	})
+}

--- a/internal/gemini/category_suggester_rapid_test.go
+++ b/internal/gemini/category_suggester_rapid_test.go
@@ -90,6 +90,20 @@ func TestExtractJSONRoundsToBraces(t *testing.T) {
 	})
 }
 
+// TestExtractJSONOpenBraceNoCloseEmpty: input with '{' but no matching '}'
+// returns "". This pins the LLM-output safety contract: truncated or
+// malformed responses must not slip past extractJSON as a valid payload.
+func TestExtractJSONOpenBraceNoCloseEmpty(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(t *rapid.T) {
+		prefix := rapid.StringMatching(`[A-Za-z ]{0,10}`).Draw(t, "prefix")
+		body := rapid.StringMatching(`[A-Za-z0-9 :",]{0,40}`).Draw(t, "body")
+		in := prefix + "{" + body
+		got := extractJSON(in)
+		require.Empty(t, got, "in=%q", in)
+	})
+}
+
 // TestHashDescriptionDeterministic: same input → same output; output is 16 hex chars.
 func TestHashDescriptionDeterministic(t *testing.T) {
 	t.Parallel()

--- a/internal/gemini/category_suggester_rapid_test.go
+++ b/internal/gemini/category_suggester_rapid_test.go
@@ -1,0 +1,128 @@
+package gemini
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+	"unicode"
+
+	"github.com/stretchr/testify/require"
+	"gitlab.com/yelinaung/expense-bot/internal/models"
+	"pgregory.net/rapid"
+)
+
+// TestSanitizeForPromptRemovesQuotesAndNulls: output contains no `"`, backtick, or NUL.
+func TestSanitizeForPromptRemovesQuotesAndNulls(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(t *rapid.T) {
+		in := rapid.String().Draw(t, "in")
+		maxLen := rapid.IntRange(1, 500).Draw(t, "maxLen")
+		got := SanitizeForPrompt(in, maxLen)
+		require.NotContains(t, got, `"`, "double quote in %q", got)
+		require.NotContains(t, got, "`", "backtick in %q", got)
+		require.NotContains(t, got, "\x00", "nul in %q", got)
+	})
+}
+
+// TestSanitizeForPromptLengthCapped: len(output) <= maxLen.
+func TestSanitizeForPromptLengthCapped(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(t *rapid.T) {
+		in := rapid.String().Draw(t, "in")
+		maxLen := rapid.IntRange(1, 500).Draw(t, "maxLen")
+		got := SanitizeForPrompt(in, maxLen)
+		require.LessOrEqual(t, len(got), maxLen, "len=%d maxLen=%d got=%q", len(got), maxLen, got)
+	})
+}
+
+// TestSanitizeForPromptNoInternalWhitespaceRuns: no consecutive whitespace and no
+// leading/trailing whitespace. Normalization collapses runs via strings.Fields.
+func TestSanitizeForPromptNoInternalWhitespaceRuns(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(t *rapid.T) {
+		in := rapid.String().Draw(t, "in")
+		maxLen := rapid.IntRange(10, 500).Draw(t, "maxLen")
+		got := SanitizeForPrompt(in, maxLen)
+		require.Equal(t, strings.TrimSpace(got), got, "not trimmed: %q", got)
+		prevSpace := false
+		for _, r := range got {
+			isSpace := unicode.IsSpace(r)
+			require.False(t, prevSpace && isSpace, "consecutive whitespace in %q", got)
+			prevSpace = isSpace
+		}
+	})
+}
+
+// TestSanitizeCategoryNameLengthCap: len(output) <= MaxCategoryNameLength.
+func TestSanitizeCategoryNameLengthCap(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(t *rapid.T) {
+		in := rapid.String().Draw(t, "in")
+		got := SanitizeCategoryName(in)
+		require.LessOrEqual(t, len(got), models.MaxCategoryNameLength)
+	})
+}
+
+// TestExtractJSONMissingBraceEmpty: input with no '{' yields "".
+func TestExtractJSONMissingBraceEmpty(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(t *rapid.T) {
+		in := rapid.StringMatching(`[A-Za-z0-9 ]{0,40}`).Draw(t, "in")
+		got := extractJSON(in)
+		require.Empty(t, got, "in=%q", in)
+	})
+}
+
+// TestExtractJSONRoundsToBraces: when '{' exists and '}' exists after it, result
+// starts with '{' and ends with '}'.
+func TestExtractJSONRoundsToBraces(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(t *rapid.T) {
+		prefix := rapid.StringMatching(`[A-Za-z ]{0,10}`).Draw(t, "prefix")
+		body := rapid.StringMatching(`[A-Za-z0-9 :",]{0,40}`).Draw(t, "body")
+		suffix := rapid.StringMatching(`[A-Za-z ]{0,10}`).Draw(t, "suffix")
+		in := prefix + "{" + body + "}" + suffix
+
+		got := extractJSON(in)
+		require.NotEmpty(t, got)
+		require.Equal(t, byte('{'), got[0])
+		require.Equal(t, byte('}'), got[len(got)-1])
+	})
+}
+
+// TestHashDescriptionDeterministic: same input → same output; output is 16 hex chars.
+func TestHashDescriptionDeterministic(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(t *rapid.T) {
+		in := rapid.String().Draw(t, "in")
+		a := hashDescription(in)
+		b := hashDescription(in)
+		require.Equal(t, a, b, "not deterministic")
+		require.Len(t, a, 16, "expected 16 hex chars")
+		_, err := hex.DecodeString(a)
+		require.NoError(t, err, "not valid hex: %q", a)
+	})
+}
+
+// TestSanitizeAvailableCategoriesDeduplicatesCaseInsensitively:
+// output has no two entries equal after ToLower.
+func TestSanitizeAvailableCategoriesDeduplicatesCaseInsensitively(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(t *rapid.T) {
+		n := rapid.IntRange(0, 10).Draw(t, "n")
+		input := make([]string, n)
+		for i := range n {
+			input[i] = rapid.StringMatching(`[A-Za-z0-9 \-]{0,20}`).Draw(t, "cat")
+		}
+		out := sanitizeAvailableCategories(input)
+
+		seen := map[string]bool{}
+		for _, c := range out {
+			require.NotEmpty(t, c, "empty entry slipped through")
+			key := strings.ToLower(c)
+			require.False(t, seen[key], "duplicate: %q", c)
+			seen[key] = true
+		}
+		require.LessOrEqual(t, len(out), len(input))
+	})
+}


### PR DESCRIPTION
Cover pure parsing, category matching, and currency helper invariants with pgregory.net/rapid. Properties exercise amount parsing bounds, tag extraction idempotence, leading-amount parse roundtrip, case-insensitive category match, normalizeCurrencyCode idempotence, and description metadata invariants.

## Summary by Sourcery

Introduce comprehensive property-based testing for bot parsing, categorization, configuration, and currency utilities, and slightly adjust username parsing and tooling configuration.

Enhancements:
- Refine whitelisted username parsing to more robustly trim whitespace and a single leading '@' before storing usernames.
- Add Rapid as a test dependency for property-based testing.

Build:
- Set GOTOOLCHAIN=auto for the golangci-lint pre-commit hook.

Tests:
- Add extensive Rapid-based property tests covering expense input parsing, amount and tag handling, CSV generation and sanitization, date range helpers, command argument extraction, category matching, and currency conversion helpers.
- Add property tests for configuration helpers including username normalization and int64 list parsing.
- Add property tests for Gemini prompt/category utilities including sanitization, JSON extraction, description hashing, and category deduplication.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  - Added extensive property-based tests across category matching, currency conversion, parsing/tag extraction, CSV generation/sanitization, date-range helpers, command-argument extraction, category suggestion, reminders, and exchange utilities.

* **Chores**
  - Introduced a property-testing dependency, updated pre-commit lint environment, and added ignore rules for test failure data.

* **Bug Fix**
  - Whitelisted-username parsing now consistently strips a leading "@" for cleaner stored usernames.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->