### PR TITLE
feat: add scheduled weekly expense report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ Thumbs.db
 
 tmp
 .cache/
+.claude/

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -236,6 +236,7 @@ func (b *Bot) Start(ctx context.Context) {
 
 	go b.startDraftCleanupLoop(ctx)
 	go b.startDailyReminderLoop(ctx)
+	go b.startWeeklyReportLoop(ctx)
 
 	logger.Log.Info().Msg("Bot started polling")
 	b.bot.Start(ctx)

--- a/internal/bot/date_range.go
+++ b/internal/bot/date_range.go
@@ -64,3 +64,12 @@ func getMonthDateRangeAt(current time.Time) (time.Time, time.Time) {
 
 	return startOfMonth, endOfMonth
 }
+
+// getPreviousWeekRangeAt returns the previous week's range as [start, end).
+// On Monday this returns [last Monday, this Monday). On other days this
+// returns the week before the current week. current must already be in the
+// desired display location.
+func getPreviousWeekRangeAt(current time.Time) (time.Time, time.Time) {
+	start, end := getWeekDateRangeAt(current)
+	return start.AddDate(0, 0, -7), end.AddDate(0, 0, -7)
+}

--- a/internal/bot/reminder.go
+++ b/internal/bot/reminder.go
@@ -3,13 +3,15 @@ package bot
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	tgbot "github.com/go-telegram/bot"
 	tgmodels "github.com/go-telegram/bot/models"
-	"github.com/shopspring/decimal"
+
 	"gitlab.com/yelinaung/expense-bot/internal/logger"
 	appmodels "gitlab.com/yelinaung/expense-bot/internal/models"
+
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	otelmetric "go.opentelemetry.io/otel/metric"
@@ -155,9 +157,13 @@ func (b *Bot) sendReminderOrDailySummary(
 		return b.sendNoExpenseReminder(ctx, user)
 	}
 
-	total := sumExpenseAmounts(expenses)
-	header := fmt.Sprintf("\U0001f4c5 <b>Today's Expenses</b> (Total: $%s)", total.StringFixed(2))
-	return b.sendTodaySummary(ctx, user.ID, expenses, header)
+	totalsByCurrency := sumExpenseAmountsByCurrency(expenses)
+	var sb strings.Builder
+	sb.WriteString("\U0001f4c5 <b>Today's Expenses</b>")
+	for cur, total := range totalsByCurrency {
+		fmt.Fprintf(&sb, "\n  %s: %s%s", cur, currencySymbol(cur), total.StringFixed(2))
+	}
+	return b.sendTodaySummary(ctx, user.ID, expenses, sb.String())
 }
 
 func (b *Bot) sendNoExpenseReminder(ctx context.Context, user *appmodels.User) error {
@@ -211,12 +217,4 @@ func (b *Bot) sendTodaySummary(
 		return fmt.Errorf("failed to send daily summary: %w", err)
 	}
 	return nil
-}
-
-func sumExpenseAmounts(expenses []appmodels.Expense) decimal.Decimal {
-	total := decimal.Zero
-	for i := range expenses {
-		total = total.Add(expenses[i].Amount)
-	}
-	return total
 }

--- a/internal/bot/reminder.go
+++ b/internal/bot/reminder.go
@@ -158,10 +158,14 @@ func (b *Bot) sendReminderOrDailySummary(
 	}
 
 	totalsByCurrency := sumExpenseAmountsByCurrency(expenses)
+	currencies := sortedCurrencyKeys(totalsByCurrency)
 	var sb strings.Builder
 	sb.WriteString("\U0001f4c5 <b>Today's Expenses</b>")
-	for cur, total := range totalsByCurrency {
-		fmt.Fprintf(&sb, "\n  %s: %s%s", cur, currencySymbol(cur), total.StringFixed(2))
+	for _, cur := range currencies {
+		fmt.Fprintf(&sb, "\n  %s: %s%s",
+			escapeHTML(cur),
+			escapeHTML(currencySymbol(cur)),
+			totalsByCurrency[cur].StringFixed(2))
 	}
 	return b.sendTodaySummary(ctx, user.ID, expenses, sb.String())
 }

--- a/internal/bot/reminder_rapid_test.go
+++ b/internal/bot/reminder_rapid_test.go
@@ -1,6 +1,7 @@
 package bot
 
 import (
+	"maps"
 	"math/rand"
 	"testing"
 
@@ -10,63 +11,88 @@ import (
 	"pgregory.net/rapid"
 )
 
-// genExpense draws an Expense with a bounded positive amount.
-func genExpense() *rapid.Generator[appmodels.Expense] {
+// genExpenseWithCurrency draws an Expense with a bounded positive amount
+// and a random currency code.
+func genExpenseWithCurrency() *rapid.Generator[appmodels.Expense] {
 	return rapid.Custom(func(t *rapid.T) appmodels.Expense {
 		v := rapid.IntRange(0, 1_000_000).Draw(t, "v")
 		exp := rapid.IntRange(-4, 2).Draw(t, "exp")
-		return appmodels.Expense{Amount: decimal.New(int64(v), int32(exp))}
+		cur := rapid.SampledFrom([]string{"SGD", "USD", "EUR"}).Draw(t, "cur")
+		return appmodels.Expense{
+			Amount:   decimal.New(int64(v), int32(exp)),
+			Currency: cur,
+		}
 	})
 }
 
-// TestSumExpenseAmountsEmptyIsZero: sum of empty or nil slice is zero.
-func TestSumExpenseAmountsEmptyIsZero(t *testing.T) {
+// TestSumExpenseAmountsByCurrencyEmptyIsEmpty: empty or nil slice
+// returns an empty map.
+func TestSumExpenseAmountsByCurrencyEmptyIsEmpty(t *testing.T) {
 	t.Parallel()
-	require.True(t, sumExpenseAmounts(nil).IsZero())
-	require.True(t, sumExpenseAmounts([]appmodels.Expense{}).IsZero())
+	require.Empty(t, sumExpenseAmountsByCurrency(nil))
+	require.Empty(t, sumExpenseAmountsByCurrency([]appmodels.Expense{}))
 }
 
-// TestSumExpenseAmountsSingletonIdentity: sum of [x] equals x.
-func TestSumExpenseAmountsSingletonIdentity(t *testing.T) {
+// TestSumExpenseAmountsByCurrencySingletonIdentity: sum of [x] equals
+// a map with x.Amount for x.Currency.
+func TestSumExpenseAmountsByCurrencySingletonIdentity(t *testing.T) {
 	t.Parallel()
 	rapid.Check(t, func(t *rapid.T) {
-		e := genExpense().Draw(t, "e")
-		require.True(t, sumExpenseAmounts([]appmodels.Expense{e}).Equal(e.Amount))
+		e := genExpenseWithCurrency().Draw(t, "e")
+		result := sumExpenseAmountsByCurrency([]appmodels.Expense{e})
+		require.Len(t, result, 1)
+		require.True(t, result[e.Currency].Equal(e.Amount))
 	})
 }
 
-// TestSumExpenseAmountsOrderInvariant: shuffling the slice doesn't change the sum.
-func TestSumExpenseAmountsOrderInvariant(t *testing.T) {
+// TestSumExpenseAmountsByCurrencyOrderInvariant: shuffling the slice
+// doesn't change the per-currency totals.
+func TestSumExpenseAmountsByCurrencyOrderInvariant(t *testing.T) {
 	t.Parallel()
 	rapid.Check(t, func(t *rapid.T) {
 		n := rapid.IntRange(0, 12).Draw(t, "n")
 		xs := make([]appmodels.Expense, n)
 		for i := range n {
-			xs[i] = genExpense().Draw(t, "x")
+			xs[i] = genExpenseWithCurrency().Draw(t, "x")
 		}
 		seed := rapid.Int64().Draw(t, "seed")
 		ys := make([]appmodels.Expense, n)
 		copy(ys, xs)
-		// Deterministic shuffle driven by rapid-chosen seed for reproducibility.
 		r := rand.New(rand.NewSource(seed))
 		r.Shuffle(n, func(i, j int) { ys[i], ys[j] = ys[j], ys[i] })
 
-		require.True(t, sumExpenseAmounts(xs).Equal(sumExpenseAmounts(ys)))
+		require.Equal(t, sumExpenseAmountsByCurrency(xs), sumExpenseAmountsByCurrency(ys))
 	})
 }
 
-// TestSumExpenseAmountsAssociativeSplit: sum(xs) == sum(xs[:k]) + sum(xs[k:]).
-func TestSumExpenseAmountsAssociativeSplit(t *testing.T) {
+// TestSumExpenseAmountsByCurrencyAssociativeSplit: merging per-currency
+// totals of split slices equals the total of the whole slice.
+func TestSumExpenseAmountsByCurrencyAssociativeSplit(t *testing.T) {
 	t.Parallel()
 	rapid.Check(t, func(t *rapid.T) {
 		n := rapid.IntRange(1, 12).Draw(t, "n")
 		xs := make([]appmodels.Expense, n)
 		for i := range n {
-			xs[i] = genExpense().Draw(t, "x")
+			xs[i] = genExpenseWithCurrency().Draw(t, "x")
 		}
 		k := rapid.IntRange(0, n).Draw(t, "k")
-		whole := sumExpenseAmounts(xs)
-		split := sumExpenseAmounts(xs[:k]).Add(sumExpenseAmounts(xs[k:]))
-		require.True(t, whole.Equal(split))
+		whole := sumExpenseAmountsByCurrency(xs)
+		left := sumExpenseAmountsByCurrency(xs[:k])
+		right := sumExpenseAmountsByCurrency(xs[k:])
+		merged := mergeCurrencyTotals(left, right)
+		require.Equal(t, whole, merged)
 	})
+}
+
+// mergeCurrencyTotals adds the values from right into left and returns
+// the combined map.
+func mergeCurrencyTotals(
+	left, right map[string]decimal.Decimal,
+) map[string]decimal.Decimal {
+	result := make(map[string]decimal.Decimal, len(left)+len(right))
+	maps.Copy(result, left)
+	for k, v := range right {
+		result[k] = result[k].Add(v)
+	}
+	return result
 }

--- a/internal/bot/weekly_report.go
+++ b/internal/bot/weekly_report.go
@@ -76,13 +76,7 @@ func (b *Bot) checkAndSendWeeklyReports(ctx context.Context, sent map[int64]stri
 	checkCtx, cancel := context.WithTimeout(ctx, WeeklyReportTimeout)
 	defer cancel()
 
-	// Prune entries older than 2 weeks.
-	cutoff := now.UTC().AddDate(0, 0, -14).Format("2006-01-02")
-	for uid, weekKey := range sent {
-		if weekKey < cutoff {
-			delete(sent, uid)
-		}
-	}
+	pruneWeeklyReportSent(sent, now)
 
 	users, err := b.userRepo.GetAuthorizedUsersForReminder(
 		checkCtx,
@@ -91,67 +85,84 @@ func (b *Bot) checkAndSendWeeklyReports(ctx context.Context, sent map[int64]stri
 	)
 	if err != nil {
 		logger.Log.Error().Err(err).Msg("Failed to fetch users for weekly report")
-		if b.metrics != nil {
-			b.metrics.BackgroundJobRuns.Add(ctx, 1, otelmetric.WithAttributes(
-				attribute.String("job", "weekly_report"),
-				attribute.String("status", "error"),
-			))
-			b.metrics.BackgroundJobDuration.Record(ctx, time.Since(start).Seconds(),
-				otelmetric.WithAttributes(attribute.String("job", "weekly_report")))
-		}
+		b.recordWeeklyReportMetrics(ctx, start, "error")
 		return
 	}
 
 	for i := range users {
-		user := &users[i]
+		b.processWeeklyReportUser(checkCtx, &users[i], sent, now)
+	}
 
-		loc := b.userLocation(user.Timezone)
-		userNow := now.In(loc)
+	b.recordWeeklyReportMetrics(ctx, start, "ok")
+}
 
-		if userNow.Weekday() != b.cfg.WeeklyReportDay {
-			continue
+// pruneWeeklyReportSent removes entries older than 2 weeks from the sent map.
+func pruneWeeklyReportSent(sent map[int64]string, now time.Time) {
+	cutoff := now.UTC().AddDate(0, 0, -14).Format("2006-01-02")
+	for uid, weekKey := range sent {
+		if weekKey < cutoff {
+			delete(sent, uid)
 		}
+	}
+}
 
-		if userNow.Hour() != b.cfg.WeeklyReportHour {
-			continue
-		}
+// processWeeklyReportUser checks whether a user should receive a weekly
+// report and sends one if needed.
+func (b *Bot) processWeeklyReportUser(
+	ctx context.Context,
+	user *appmodels.User,
+	sent map[int64]string,
+	now time.Time,
+) {
+	loc := b.userLocation(user.Timezone)
+	userNow := now.In(loc)
 
-		// Build a key from the previous week's Monday date.
-		prevStart, _ := getPreviousWeekRangeAt(userNow)
-		weekKey := prevStart.Format("2006-01-02")
-		if sent[user.ID] == weekKey {
-			continue
-		}
+	if userNow.Weekday() != b.cfg.WeeklyReportDay {
+		return
+	}
+	if userNow.Hour() != b.cfg.WeeklyReportHour {
+		return
+	}
 
-		sentOK, err := b.sendWeeklySummary(checkCtx, user, userNow)
-		if err != nil {
-			logger.Log.Warn().Err(err).
-				Str("user_hash", logger.HashUserID(user.ID)).
-				Msg("Failed to send weekly report")
-			continue
-		}
-		if !sentOK {
-			logger.Log.Debug().
-				Str("user_hash", logger.HashUserID(user.ID)).
-				Msg("No weekly expenses; skipping report")
-			continue
-		}
+	prevStart, _ := getPreviousWeekRangeAt(userNow)
+	weekKey := prevStart.Format("2006-01-02")
+	if sent[user.ID] == weekKey {
+		return
+	}
 
-		sent[user.ID] = weekKey
+	sentOK, err := b.sendWeeklySummary(ctx, user, userNow)
+	if err != nil {
+		logger.Log.Warn().Err(err).
+			Str("user_hash", logger.HashUserID(user.ID)).
+			Msg("Failed to send weekly report")
+		return
+	}
+	if !sentOK {
 		logger.Log.Debug().
 			Str("user_hash", logger.HashUserID(user.ID)).
-			Str("timezone", loc.String()).
-			Msg("Sent weekly report")
+			Msg("No weekly expenses; skipping report")
+		return
 	}
 
-	if b.metrics != nil {
-		b.metrics.BackgroundJobRuns.Add(ctx, 1, otelmetric.WithAttributes(
-			attribute.String("job", "weekly_report"),
-			attribute.String("status", "ok"),
-		))
-		b.metrics.BackgroundJobDuration.Record(ctx, time.Since(start).Seconds(),
-			otelmetric.WithAttributes(attribute.String("job", "weekly_report")))
+	sent[user.ID] = weekKey
+	logger.Log.Debug().
+		Str("user_hash", logger.HashUserID(user.ID)).
+		Str("timezone", loc.String()).
+		Msg("Sent weekly report")
+}
+
+// recordWeeklyReportMetrics records background job metrics for the
+// weekly report run.
+func (b *Bot) recordWeeklyReportMetrics(ctx context.Context, start time.Time, status string) {
+	if b.metrics == nil {
+		return
 	}
+	b.metrics.BackgroundJobRuns.Add(ctx, 1, otelmetric.WithAttributes(
+		attribute.String("job", "weekly_report"),
+		attribute.String("status", status),
+	))
+	b.metrics.BackgroundJobDuration.Record(ctx, time.Since(start).Seconds(),
+		otelmetric.WithAttributes(attribute.String("job", "weekly_report")))
 }
 
 // sendWeeklySummary sends a weekly expense summary to the user.

--- a/internal/bot/weekly_report.go
+++ b/internal/bot/weekly_report.go
@@ -3,6 +3,7 @@ package bot
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -173,14 +174,18 @@ func (b *Bot) sendWeeklySummary(
 	}
 
 	totalsByCurrency := sumExpenseAmountsByCurrency(expenses)
+	currencies := sortedCurrencyKeys(totalsByCurrency)
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "📊 <b>Weekly Expenses</b> (%s to %s)\n%d expenses",
 		startOfWeek.Format("Jan 2"),
 		endOfWeek.AddDate(0, 0, -1).Format("Jan 2, 2006"),
 		len(expenses),
 	)
-	for cur, total := range totalsByCurrency {
-		fmt.Fprintf(&sb, "\n  %s: %s%s", cur, currencySymbol(cur), total.StringFixed(2))
+	for _, cur := range currencies {
+		fmt.Fprintf(&sb, "\n  %s: %s%s",
+			escapeHTML(cur),
+			escapeHTML(currencySymbol(cur)),
+			totalsByCurrency[cur].StringFixed(2))
 	}
 	header := sb.String()
 
@@ -226,4 +231,15 @@ func currencySymbol(code string) string {
 		return s
 	}
 	return code
+}
+
+// sortedCurrencyKeys returns the keys of a currency→amount map sorted
+// alphabetically for deterministic output ordering.
+func sortedCurrencyKeys(totals map[string]decimal.Decimal) []string {
+	keys := make([]string, 0, len(totals))
+	for k := range totals {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }

--- a/internal/bot/weekly_report.go
+++ b/internal/bot/weekly_report.go
@@ -3,12 +3,16 @@ package bot
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	tgbot "github.com/go-telegram/bot"
 	tgmodels "github.com/go-telegram/bot/models"
+	"github.com/shopspring/decimal"
+
 	"gitlab.com/yelinaung/expense-bot/internal/logger"
 	appmodels "gitlab.com/yelinaung/expense-bot/internal/models"
+
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	otelmetric "go.opentelemetry.io/otel/metric"
@@ -30,7 +34,7 @@ func (b *Bot) startWeeklyReportLoop(ctx context.Context) {
 	}
 
 	logger.Log.Info().
-		Int("day", b.cfg.WeeklyReportDay).
+		Str("day", b.cfg.WeeklyReportDay.String()).
 		Int("hour", b.cfg.WeeklyReportHour).
 		Msg("Weekly report loop started (per-user timezone)")
 
@@ -45,7 +49,8 @@ func (b *Bot) startWeeklyReportLoop(ctx context.Context) {
 	default:
 	}
 
-	// Run one check immediately.
+	// Run one check immediately so reports aren't skipped when the
+	// process starts during the configured window.
 	b.checkAndSendWeeklyReports(ctx, sent, b.now())
 
 	for {
@@ -102,7 +107,7 @@ func (b *Bot) checkAndSendWeeklyReports(ctx context.Context, sent map[int64]stri
 		loc := b.userLocation(user.Timezone)
 		userNow := now.In(loc)
 
-		if int(userNow.Weekday()) != b.cfg.WeeklyReportDay {
+		if userNow.Weekday() != b.cfg.WeeklyReportDay {
 			continue
 		}
 
@@ -117,14 +122,25 @@ func (b *Bot) checkAndSendWeeklyReports(ctx context.Context, sent map[int64]stri
 			continue
 		}
 
-		err = b.sendWeeklySummary(checkCtx, user, userNow)
+		sentOK, err := b.sendWeeklySummary(checkCtx, user, userNow)
 		if err != nil {
-			logger.Log.Warn().Err(err).Str("user_hash", logger.HashUserID(user.ID)).Msg("Failed to send weekly report")
+			logger.Log.Warn().Err(err).
+				Str("user_hash", logger.HashUserID(user.ID)).
+				Msg("Failed to send weekly report")
+			continue
+		}
+		if !sentOK {
+			logger.Log.Debug().
+				Str("user_hash", logger.HashUserID(user.ID)).
+				Msg("No weekly expenses; skipping report")
 			continue
 		}
 
 		sent[user.ID] = weekKey
-		logger.Log.Debug().Str("user_hash", logger.HashUserID(user.ID)).Str("timezone", loc.String()).Msg("Sent weekly report")
+		logger.Log.Debug().
+			Str("user_hash", logger.HashUserID(user.ID)).
+			Str("timezone", loc.String()).
+			Msg("Sent weekly report")
 	}
 
 	if b.metrics != nil {
@@ -137,29 +153,36 @@ func (b *Bot) checkAndSendWeeklyReports(ctx context.Context, sent map[int64]stri
 	}
 }
 
+// sendWeeklySummary sends a weekly expense summary to the user.
+// The returned bool indicates whether a message was actually sent.
+// When there are no expenses, (false, nil) is returned.
 func (b *Bot) sendWeeklySummary(
 	ctx context.Context,
 	user *appmodels.User,
 	userNow time.Time,
-) error {
+) (bool, error) {
 	startOfWeek, endOfWeek := getPreviousWeekRangeAt(userNow)
 
 	expenses, err := b.expenseRepo.GetByUserIDAndDateRange(ctx, user.ID, startOfWeek, endOfWeek)
 	if err != nil {
-		return fmt.Errorf("failed to fetch weekly expenses: %w", err)
+		return false, fmt.Errorf("failed to fetch weekly expenses: %w", err)
 	}
 
 	if len(expenses) == 0 {
-		return nil // No expenses this week, skip silently.
+		return false, nil
 	}
 
-	total := sumExpenseAmounts(expenses)
-	header := fmt.Sprintf("📊 <b>Weekly Expenses</b> (%s to %s)\nTotal: $%s | %d expenses",
+	totalsByCurrency := sumExpenseAmountsByCurrency(expenses)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "📊 <b>Weekly Expenses</b> (%s to %s)\n%d expenses",
 		startOfWeek.Format("Jan 2"),
 		endOfWeek.AddDate(0, 0, -1).Format("Jan 2, 2006"),
-		total.StringFixed(2),
 		len(expenses),
 	)
+	for cur, total := range totalsByCurrency {
+		fmt.Fprintf(&sb, "\n  %s: %s%s", cur, currencySymbol(cur), total.StringFixed(2))
+	}
+	header := sb.String()
 
 	expenseIDs := make([]int, len(expenses))
 	for i := range expenses {
@@ -182,7 +205,25 @@ func (b *Bot) sendWeeklySummary(
 		ParseMode: tgmodels.ParseModeHTML,
 	})
 	if err != nil {
-		return fmt.Errorf("failed to send weekly summary: %w", err)
+		return false, fmt.Errorf("failed to send weekly summary: %w", err)
 	}
-	return nil
+	return true, nil
+}
+
+// sumExpenseAmountsByCurrency returns expense totals grouped by currency.
+func sumExpenseAmountsByCurrency(expenses []appmodels.Expense) map[string]decimal.Decimal {
+	totals := make(map[string]decimal.Decimal)
+	for i := range expenses {
+		e := expenses[i]
+		totals[e.Currency] = totals[e.Currency].Add(e.Amount)
+	}
+	return totals
+}
+
+// currencySymbol returns the display symbol for a currency code.
+func currencySymbol(code string) string {
+	if s := appmodels.SupportedCurrencies[code]; s != "" {
+		return s
+	}
+	return code
 }

--- a/internal/bot/weekly_report.go
+++ b/internal/bot/weekly_report.go
@@ -1,0 +1,188 @@
+package bot
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	tgbot "github.com/go-telegram/bot"
+	tgmodels "github.com/go-telegram/bot/models"
+	"gitlab.com/yelinaung/expense-bot/internal/logger"
+	appmodels "gitlab.com/yelinaung/expense-bot/internal/models"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	otelmetric "go.opentelemetry.io/otel/metric"
+)
+
+const (
+	// WeeklyReportCheckInterval is how often the weekly report loop runs.
+	WeeklyReportCheckInterval = 30 * time.Minute
+	// WeeklyReportTimeout is the maximum time a single check can take.
+	WeeklyReportTimeout = 2 * time.Minute
+)
+
+// startWeeklyReportLoop runs a periodic loop that sends weekly expense
+// summaries to users on the configured day and hour.
+func (b *Bot) startWeeklyReportLoop(ctx context.Context) {
+	if !b.cfg.WeeklyReportEnabled {
+		logger.Log.Info().Msg("Weekly report is disabled")
+		return
+	}
+
+	logger.Log.Info().
+		Int("day", b.cfg.WeeklyReportDay).
+		Int("hour", b.cfg.WeeklyReportHour).
+		Msg("Weekly report loop started (per-user timezone)")
+
+	sent := make(map[int64]string)
+	ticker := time.NewTicker(WeeklyReportCheckInterval)
+	defer ticker.Stop()
+
+	select {
+	case <-ctx.Done():
+		logger.Log.Info().Msg("Weekly report loop stopped")
+		return
+	default:
+	}
+
+	// Run one check immediately.
+	b.checkAndSendWeeklyReports(ctx, sent, b.now())
+
+	for {
+		select {
+		case <-ctx.Done():
+			logger.Log.Info().Msg("Weekly report loop stopped")
+			return
+		case <-ticker.C:
+			b.checkAndSendWeeklyReports(ctx, sent, b.now())
+		}
+	}
+}
+
+// checkAndSendWeeklyReports sends weekly summaries to authorized users
+// whose local weekday and hour match the configured WeeklyReportDay and
+// WeeklyReportHour.
+func (b *Bot) checkAndSendWeeklyReports(ctx context.Context, sent map[int64]string, now time.Time) {
+	ctx, span := otel.Tracer("expense-bot/background").Start(ctx, "background.weekly_report_check")
+	defer span.End()
+	start := time.Now()
+
+	checkCtx, cancel := context.WithTimeout(ctx, WeeklyReportTimeout)
+	defer cancel()
+
+	// Prune entries older than 2 weeks.
+	cutoff := now.UTC().AddDate(0, 0, -14).Format("2006-01-02")
+	for uid, weekKey := range sent {
+		if weekKey < cutoff {
+			delete(sent, uid)
+		}
+	}
+
+	users, err := b.userRepo.GetAuthorizedUsersForReminder(
+		checkCtx,
+		b.cfg.WhitelistedUserIDs,
+		b.cfg.WhitelistedUsernames,
+	)
+	if err != nil {
+		logger.Log.Error().Err(err).Msg("Failed to fetch users for weekly report")
+		if b.metrics != nil {
+			b.metrics.BackgroundJobRuns.Add(ctx, 1, otelmetric.WithAttributes(
+				attribute.String("job", "weekly_report"),
+				attribute.String("status", "error"),
+			))
+			b.metrics.BackgroundJobDuration.Record(ctx, time.Since(start).Seconds(),
+				otelmetric.WithAttributes(attribute.String("job", "weekly_report")))
+		}
+		return
+	}
+
+	for i := range users {
+		user := &users[i]
+
+		loc := b.userLocation(user.Timezone)
+		userNow := now.In(loc)
+
+		if int(userNow.Weekday()) != b.cfg.WeeklyReportDay {
+			continue
+		}
+
+		if userNow.Hour() != b.cfg.WeeklyReportHour {
+			continue
+		}
+
+		// Build a key from the previous week's Monday date.
+		prevStart, _ := getPreviousWeekRangeAt(userNow)
+		weekKey := prevStart.Format("2006-01-02")
+		if sent[user.ID] == weekKey {
+			continue
+		}
+
+		err = b.sendWeeklySummary(checkCtx, user, userNow)
+		if err != nil {
+			logger.Log.Warn().Err(err).Str("user_hash", logger.HashUserID(user.ID)).Msg("Failed to send weekly report")
+			continue
+		}
+
+		sent[user.ID] = weekKey
+		logger.Log.Debug().Str("user_hash", logger.HashUserID(user.ID)).Str("timezone", loc.String()).Msg("Sent weekly report")
+	}
+
+	if b.metrics != nil {
+		b.metrics.BackgroundJobRuns.Add(ctx, 1, otelmetric.WithAttributes(
+			attribute.String("job", "weekly_report"),
+			attribute.String("status", "ok"),
+		))
+		b.metrics.BackgroundJobDuration.Record(ctx, time.Since(start).Seconds(),
+			otelmetric.WithAttributes(attribute.String("job", "weekly_report")))
+	}
+}
+
+func (b *Bot) sendWeeklySummary(
+	ctx context.Context,
+	user *appmodels.User,
+	userNow time.Time,
+) error {
+	startOfWeek, endOfWeek := getPreviousWeekRangeAt(userNow)
+
+	expenses, err := b.expenseRepo.GetByUserIDAndDateRange(ctx, user.ID, startOfWeek, endOfWeek)
+	if err != nil {
+		return fmt.Errorf("failed to fetch weekly expenses: %w", err)
+	}
+
+	if len(expenses) == 0 {
+		return nil // No expenses this week, skip silently.
+	}
+
+	total := sumExpenseAmounts(expenses)
+	header := fmt.Sprintf("📊 <b>Weekly Expenses</b> (%s to %s)\nTotal: $%s | %d expenses",
+		startOfWeek.Format("Jan 2"),
+		endOfWeek.AddDate(0, 0, -1).Format("Jan 2, 2006"),
+		total.StringFixed(2),
+		len(expenses),
+	)
+
+	expenseIDs := make([]int, len(expenses))
+	for i := range expenses {
+		expenseIDs[i] = expenses[i].ID
+	}
+
+	tagsByExpense := map[int][]appmodels.Tag{}
+	if b.tagRepo != nil {
+		var tagErr error
+		tagsByExpense, tagErr = b.tagRepo.GetByExpenseIDs(ctx, expenseIDs)
+		if tagErr != nil {
+			logger.Log.Warn().Err(tagErr).Msg("Failed to batch-load tags for weekly summary")
+		}
+	}
+
+	text := b.buildExpenseListMessage(header, expenses, tagsByExpense)
+	_, err = b.messageSender.SendMessage(ctx, &tgbot.SendMessageParams{
+		ChatID:    user.ID,
+		Text:      text,
+		ParseMode: tgmodels.ParseModeHTML,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to send weekly summary: %w", err)
+	}
+	return nil
+}

--- a/internal/bot/weekly_report_test.go
+++ b/internal/bot/weekly_report_test.go
@@ -66,7 +66,7 @@ func TestCheckAndSendWeeklyReports(t *testing.T) {
 		require.Contains(t, msg.Text, "Apr 27")
 		require.Contains(t, msg.Text, "May 3, 2026")
 		require.Contains(t, msg.Text, "Lunch")
-		require.Contains(t, msg.Text, "SGD: $31.50")
+		require.Contains(t, msg.Text, "SGD: S$31.50")
 		require.Equal(t, "2026-04-27", sent[4001])
 	})
 

--- a/internal/bot/weekly_report_test.go
+++ b/internal/bot/weekly_report_test.go
@@ -248,6 +248,10 @@ func TestCheckAndSendWeeklyReports(t *testing.T) {
 
 		_, exists := sent[4007]
 		require.False(t, exists, "should not mark as sent on failure")
+		// No message was actually sent because the mock returns an
+		// error before recording. This distinguishes "attempted
+		// but failed" from "skipped entirely."
+		require.Equal(t, 0, mockBot.SentMessageCount())
 	})
 
 	t.Run("prunes stale entries from sent map", func(t *testing.T) {

--- a/internal/bot/weekly_report_test.go
+++ b/internal/bot/weekly_report_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/require"
+
 	"gitlab.com/yelinaung/expense-bot/internal/bot/mocks"
 	"gitlab.com/yelinaung/expense-bot/internal/models"
 )
@@ -25,8 +26,8 @@ func TestCheckAndSendWeeklyReports(t *testing.T) {
 		mockBot := mocks.NewMockBot()
 		b.messageSender = mockBot
 		b.cfg.WeeklyReportEnabled = true
-		b.cfg.WeeklyReportDay = 1  // Monday
-		b.cfg.WeeklyReportHour = 9 // 9 AM
+		b.cfg.WeeklyReportDay = time.Monday
+		b.cfg.WeeklyReportHour = 9
 		b.cfg.WhitelistedUserIDs = []int64{4001}
 
 		err := b.userRepo.UpsertUser(ctx, &models.User{
@@ -65,6 +66,7 @@ func TestCheckAndSendWeeklyReports(t *testing.T) {
 		require.Contains(t, msg.Text, "Apr 27")
 		require.Contains(t, msg.Text, "May 3, 2026")
 		require.Contains(t, msg.Text, "Lunch")
+		require.Contains(t, msg.Text, "SGD: $31.50")
 		require.Equal(t, "2026-04-27", sent[4001])
 	})
 
@@ -76,7 +78,7 @@ func TestCheckAndSendWeeklyReports(t *testing.T) {
 		mockBot := mocks.NewMockBot()
 		b.messageSender = mockBot
 		b.cfg.WeeklyReportEnabled = true
-		b.cfg.WeeklyReportDay = 1
+		b.cfg.WeeklyReportDay = time.Monday
 		b.cfg.WeeklyReportHour = 9
 		b.cfg.WhitelistedUserIDs = []int64{4002}
 
@@ -103,8 +105,8 @@ func TestCheckAndSendWeeklyReports(t *testing.T) {
 		mockBot := mocks.NewMockBot()
 		b.messageSender = mockBot
 		b.cfg.WeeklyReportEnabled = true
-		b.cfg.WeeklyReportDay = 1  // Monday
-		b.cfg.WeeklyReportHour = 9 // 9 AM
+		b.cfg.WeeklyReportDay = time.Monday
+		b.cfg.WeeklyReportHour = 9
 		b.cfg.WhitelistedUserIDs = []int64{4003}
 
 		tuesdayUTC := time.Date(2026, 5, 5, 1, 0, 0, 0, time.UTC) // Tuesday
@@ -132,7 +134,7 @@ func TestCheckAndSendWeeklyReports(t *testing.T) {
 		mockBot := mocks.NewMockBot()
 		b.messageSender = mockBot
 		b.cfg.WeeklyReportEnabled = true
-		b.cfg.WeeklyReportDay = 1
+		b.cfg.WeeklyReportDay = time.Monday
 		b.cfg.WeeklyReportHour = 9
 		b.cfg.WhitelistedUserIDs = []int64{4004}
 
@@ -161,7 +163,7 @@ func TestCheckAndSendWeeklyReports(t *testing.T) {
 		mockBot := mocks.NewMockBot()
 		b.messageSender = mockBot
 		b.cfg.WeeklyReportEnabled = true
-		b.cfg.WeeklyReportDay = 1
+		b.cfg.WeeklyReportDay = time.Monday
 		b.cfg.WeeklyReportHour = 9
 		b.cfg.WhitelistedUserIDs = []int64{4005}
 
@@ -190,7 +192,7 @@ func TestCheckAndSendWeeklyReports(t *testing.T) {
 		mockBot := mocks.NewMockBot()
 		b.messageSender = mockBot
 		b.cfg.WeeklyReportEnabled = true
-		b.cfg.WeeklyReportDay = 1
+		b.cfg.WeeklyReportDay = time.Monday
 		b.cfg.WeeklyReportHour = 9
 		b.cfg.WhitelistedUserIDs = nil
 
@@ -216,7 +218,7 @@ func TestCheckAndSendWeeklyReports(t *testing.T) {
 		mockBot.SendMessageError = errors.New("user blocked bot")
 		b.messageSender = mockBot
 		b.cfg.WeeklyReportEnabled = true
-		b.cfg.WeeklyReportDay = 1
+		b.cfg.WeeklyReportDay = time.Monday
 		b.cfg.WeeklyReportHour = 9
 		b.cfg.WhitelistedUserIDs = []int64{4007}
 
@@ -229,7 +231,7 @@ func TestCheckAndSendWeeklyReports(t *testing.T) {
 		err = b.userRepo.UpdateTimezone(ctx, 4007, "Etc/GMT-8")
 		require.NoError(t, err)
 
-		// Create an expense in previous week.
+		// Create an expense in the previous week.
 		prevMonday := time.Date(2026, 4, 27, 10, 0, 0, 0, loc)
 		expense := &models.Expense{
 			UserID:      4007,
@@ -249,8 +251,8 @@ func TestCheckAndSendWeeklyReports(t *testing.T) {
 		_, exists := sent[4007]
 		require.False(t, exists, "should not mark as sent on failure")
 		// No message was actually sent because the mock returns an
-		// error before recording. This distinguishes "attempted
-		// but failed" from "skipped entirely."
+		// error before recording. This distinguishes "attempted but
+		// failed" from "skipped entirely."
 		require.Equal(t, 0, mockBot.SentMessageCount())
 	})
 
@@ -262,14 +264,14 @@ func TestCheckAndSendWeeklyReports(t *testing.T) {
 		mockBot := mocks.NewMockBot()
 		b.messageSender = mockBot
 		b.cfg.WeeklyReportEnabled = true
-		b.cfg.WeeklyReportDay = 1
+		b.cfg.WeeklyReportDay = time.Monday
 		b.cfg.WeeklyReportHour = 9
 		b.cfg.WhitelistedUserIDs = []int64{4008}
 
 		sent := map[int64]string{
-			9001: "2026-04-01", // month ago — should be pruned
-			9002: "2026-04-20", // 2 weeks ago — should survive (cutoff is 14 days)
-			9003: "2026-04-27", // last week — should survive
+			9001: "2026-04-01", // A month ago — should be pruned.
+			9002: "2026-04-20", // Two weeks ago — should survive (cutoff is 14 days).
+			9003: "2026-04-27", // Last week — should survive.
 		}
 
 		b.checkAndSendWeeklyReports(ctx, sent, monday9amUTC)
@@ -288,7 +290,7 @@ func TestCheckAndSendWeeklyReports(t *testing.T) {
 		mockBot := mocks.NewMockBot()
 		b.messageSender = mockBot
 		b.cfg.WeeklyReportEnabled = true
-		b.cfg.WeeklyReportDay = 1
+		b.cfg.WeeklyReportDay = time.Monday
 		b.cfg.WeeklyReportHour = 9
 		b.cfg.WhitelistedUserIDs = []int64{4009}
 
@@ -301,7 +303,7 @@ func TestCheckAndSendWeeklyReports(t *testing.T) {
 		err = b.userRepo.UpdateTimezone(ctx, 4009, "")
 		require.NoError(t, err)
 
-		// Create expense in previous week.
+		// Create expense in the previous week.
 		prevMonday := time.Date(2026, 4, 27, 10, 0, 0, 0, loc)
 		expense := &models.Expense{
 			UserID:      4009,
@@ -329,11 +331,12 @@ func TestCheckAndSendWeeklyReports(t *testing.T) {
 		mockBot := mocks.NewMockBot()
 		b.messageSender = mockBot
 		b.cfg.WeeklyReportEnabled = true
-		b.cfg.WeeklyReportDay = 1  // Monday
-		b.cfg.WeeklyReportHour = 9 // 9 AM
+		b.cfg.WeeklyReportDay = time.Monday
+		b.cfg.WeeklyReportHour = 9
 		b.cfg.WhitelistedUserIDs = []int64{4101, 4102}
 
-		// User in GMT+8: at 01:00 UTC Monday = 09:00 local → matches
+		// Etc/GMT-8 means UTC+8. At 01:00 UTC Monday it is
+		// 09:00 local Monday — matches the configured hour.
 		err := b.userRepo.UpsertUser(ctx, &models.User{
 			ID:        4101,
 			Username:  "sguser",
@@ -343,17 +346,18 @@ func TestCheckAndSendWeeklyReports(t *testing.T) {
 		err = b.userRepo.UpdateTimezone(ctx, 4101, "Etc/GMT-8")
 		require.NoError(t, err)
 
-		// User in GMT+5: at 01:00 UTC Monday = 06:00 local → doesn't match
+		// Etc/GMT+5 means UTC-5. At 01:00 UTC Monday it is
+		// 20:00 (8 PM) Sunday local — does not match.
 		err = b.userRepo.UpsertUser(ctx, &models.User{
 			ID:        4102,
-			Username:  "eastuser",
-			FirstName: "East",
+			Username:  "westuser",
+			FirstName: "West",
 		})
 		require.NoError(t, err)
 		err = b.userRepo.UpdateTimezone(ctx, 4102, "Etc/GMT+5")
 		require.NoError(t, err)
 
-		// Create expense for both users in previous week.
+		// Create expense for both users in the previous week.
 		prevMonday := time.Date(2026, 4, 27, 10, 0, 0, 0, time.UTC)
 		for _, uid := range []int64{4101, 4102} {
 			expense := &models.Expense{
@@ -386,7 +390,7 @@ func TestCheckAndSendWeeklyReports(t *testing.T) {
 		b.messageSender = mockBot
 		b.tagRepo = nil
 		b.cfg.WeeklyReportEnabled = true
-		b.cfg.WeeklyReportDay = 1
+		b.cfg.WeeklyReportDay = time.Monday
 		b.cfg.WeeklyReportHour = 9
 		b.cfg.WhitelistedUserIDs = []int64{4103}
 
@@ -464,8 +468,8 @@ func TestStartWeeklyReportLoop_RunsImmediateCheck(t *testing.T) {
 	mockBot := mocks.NewMockBot()
 	b.messageSender = mockBot
 	b.cfg.WeeklyReportEnabled = true
-	b.cfg.WeeklyReportDay = 1  // Monday
-	b.cfg.WeeklyReportHour = 9 // 9 AM
+	b.cfg.WeeklyReportDay = time.Monday
+	b.cfg.WeeklyReportHour = 9
 	b.cfg.WhitelistedUserIDs = []int64{5001}
 
 	err := b.userRepo.UpsertUser(ctx, &models.User{
@@ -521,13 +525,14 @@ func TestSendWeeklySummary_FetchError(t *testing.T) {
 	canceledCtx, cancel := context.WithCancel(ctx)
 	cancel()
 
-	err := b.sendWeeklySummary(
+	sent, err := b.sendWeeklySummary(
 		canceledCtx,
 		&models.User{ID: 5002, FirstName: "Err"},
 		time.Now(),
 	)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to fetch weekly expenses")
+	require.False(t, sent)
 }
 
 func TestCheckAndSendWeeklyReports_FetchUsersError(t *testing.T) {
@@ -535,7 +540,7 @@ func TestCheckAndSendWeeklyReports_FetchUsersError(t *testing.T) {
 	pool := testDB(ctx, t)
 	b := setupTestBot(t, pool)
 	b.cfg.WeeklyReportEnabled = true
-	b.cfg.WeeklyReportDay = 1
+	b.cfg.WeeklyReportDay = time.Monday
 	b.cfg.WeeklyReportHour = 9
 	b.cfg.WhitelistedUserIDs = []int64{5003}
 

--- a/internal/bot/weekly_report_test.go
+++ b/internal/bot/weekly_report_test.go
@@ -1,0 +1,446 @@
+package bot
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/require"
+	"gitlab.com/yelinaung/expense-bot/internal/bot/mocks"
+	"gitlab.com/yelinaung/expense-bot/internal/models"
+)
+
+func TestCheckAndSendWeeklyReports(t *testing.T) {
+	loc := time.FixedZone("GMT+8", 8*60*60)
+	// 2026-05-04 is a Monday. 09:00 GMT+8 = 01:00 UTC.
+	monday9amUTC := time.Date(2026, 5, 4, 1, 0, 0, 0, time.UTC)
+
+	t.Run("sends weekly summary on Monday at configured hour", func(t *testing.T) {
+		ctx := context.Background()
+		pool := testDB(ctx, t)
+		b := setupTestBot(t, pool)
+		b.displayLocation = loc
+		mockBot := mocks.NewMockBot()
+		b.messageSender = mockBot
+		b.cfg.WeeklyReportEnabled = true
+		b.cfg.WeeklyReportDay = 1  // Monday
+		b.cfg.WeeklyReportHour = 9 // 9 AM
+		b.cfg.WhitelistedUserIDs = []int64{4001}
+
+		err := b.userRepo.UpsertUser(ctx, &models.User{
+			ID:        4001,
+			Username:  "weeklyuser",
+			FirstName: "Alice",
+		})
+		require.NoError(t, err)
+		err = b.userRepo.UpdateTimezone(ctx, 4001, "Etc/GMT-8")
+		require.NoError(t, err)
+
+		// Create expenses in the previous week (Apr 27 - May 3).
+		prevMonday := time.Date(2026, 4, 27, 10, 0, 0, 0, loc)
+		for i := range 3 {
+			expense := &models.Expense{
+				UserID:      4001,
+				Amount:      decimal.NewFromFloat(10.50),
+				Currency:    "SGD",
+				Description: "Lunch",
+				Status:      models.ExpenseStatusConfirmed,
+			}
+			err = b.expenseRepo.Create(ctx, expense)
+			require.NoError(t, err)
+			_, err = b.db.Exec(ctx, testUpdateExpenseTimeSQL,
+				prevMonday.Add(time.Duration(i)*24*time.Hour), expense.ID)
+			require.NoError(t, err)
+		}
+
+		sent := make(map[int64]string)
+		b.checkAndSendWeeklyReports(ctx, sent, monday9amUTC)
+
+		require.Equal(t, 1, mockBot.SentMessageCount())
+		msg := mockBot.LastSentMessage()
+		require.Equal(t, int64(4001), msg.ChatID)
+		require.Contains(t, msg.Text, "Weekly Expenses")
+		require.Contains(t, msg.Text, "Apr 27")
+		require.Contains(t, msg.Text, "May 3, 2026")
+		require.Contains(t, msg.Text, "Lunch")
+		require.Equal(t, "2026-04-27", sent[4001])
+	})
+
+	t.Run("skips when user has no expenses in previous week", func(t *testing.T) {
+		ctx := context.Background()
+		pool := testDB(ctx, t)
+		b := setupTestBot(t, pool)
+		b.displayLocation = loc
+		mockBot := mocks.NewMockBot()
+		b.messageSender = mockBot
+		b.cfg.WeeklyReportEnabled = true
+		b.cfg.WeeklyReportDay = 1
+		b.cfg.WeeklyReportHour = 9
+		b.cfg.WhitelistedUserIDs = []int64{4002}
+
+		err := b.userRepo.UpsertUser(ctx, &models.User{
+			ID:        4002,
+			Username:  "emptyweek",
+			FirstName: "Bob",
+		})
+		require.NoError(t, err)
+		err = b.userRepo.UpdateTimezone(ctx, 4002, "Etc/GMT-8")
+		require.NoError(t, err)
+
+		sent := make(map[int64]string)
+		b.checkAndSendWeeklyReports(ctx, sent, monday9amUTC)
+
+		require.Equal(t, 0, mockBot.SentMessageCount(), "should skip user with no expenses")
+	})
+
+	t.Run("skips when weekday does not match", func(t *testing.T) {
+		ctx := context.Background()
+		pool := testDB(ctx, t)
+		b := setupTestBot(t, pool)
+		b.displayLocation = loc
+		mockBot := mocks.NewMockBot()
+		b.messageSender = mockBot
+		b.cfg.WeeklyReportEnabled = true
+		b.cfg.WeeklyReportDay = 1  // Monday
+		b.cfg.WeeklyReportHour = 9 // 9 AM
+		b.cfg.WhitelistedUserIDs = []int64{4003}
+
+		tuesdayUTC := time.Date(2026, 5, 5, 1, 0, 0, 0, time.UTC) // Tuesday
+
+		err := b.userRepo.UpsertUser(ctx, &models.User{
+			ID:        4003,
+			Username:  "wrongday",
+			FirstName: "Charlie",
+		})
+		require.NoError(t, err)
+		err = b.userRepo.UpdateTimezone(ctx, 4003, "Etc/GMT-8")
+		require.NoError(t, err)
+
+		sent := make(map[int64]string)
+		b.checkAndSendWeeklyReports(ctx, sent, tuesdayUTC)
+
+		require.Equal(t, 0, mockBot.SentMessageCount(), "should skip on Tuesday")
+	})
+
+	t.Run("skips when hour does not match", func(t *testing.T) {
+		ctx := context.Background()
+		pool := testDB(ctx, t)
+		b := setupTestBot(t, pool)
+		b.displayLocation = loc
+		mockBot := mocks.NewMockBot()
+		b.messageSender = mockBot
+		b.cfg.WeeklyReportEnabled = true
+		b.cfg.WeeklyReportDay = 1
+		b.cfg.WeeklyReportHour = 9
+		b.cfg.WhitelistedUserIDs = []int64{4004}
+
+		wrongHourUTC := time.Date(2026, 5, 4, 2, 0, 0, 0, time.UTC) // Monday 10 AM GMT+8
+
+		err := b.userRepo.UpsertUser(ctx, &models.User{
+			ID:        4004,
+			Username:  "wronghour",
+			FirstName: "Diana",
+		})
+		require.NoError(t, err)
+		err = b.userRepo.UpdateTimezone(ctx, 4004, "Etc/GMT-8")
+		require.NoError(t, err)
+
+		sent := make(map[int64]string)
+		b.checkAndSendWeeklyReports(ctx, sent, wrongHourUTC)
+
+		require.Equal(t, 0, mockBot.SentMessageCount(), "should skip at wrong hour")
+	})
+
+	t.Run("skips user already sent for this week", func(t *testing.T) {
+		ctx := context.Background()
+		pool := testDB(ctx, t)
+		b := setupTestBot(t, pool)
+		b.displayLocation = loc
+		mockBot := mocks.NewMockBot()
+		b.messageSender = mockBot
+		b.cfg.WeeklyReportEnabled = true
+		b.cfg.WeeklyReportDay = 1
+		b.cfg.WeeklyReportHour = 9
+		b.cfg.WhitelistedUserIDs = []int64{4005}
+
+		err := b.userRepo.UpsertUser(ctx, &models.User{
+			ID:        4005,
+			Username:  "alreadysent",
+			FirstName: "Eve",
+		})
+		require.NoError(t, err)
+		err = b.userRepo.UpdateTimezone(ctx, 4005, "Etc/GMT-8")
+		require.NoError(t, err)
+
+		sent := map[int64]string{
+			4005: "2026-04-27",
+		}
+		b.checkAndSendWeeklyReports(ctx, sent, monday9amUTC)
+
+		require.Equal(t, 0, mockBot.SentMessageCount(), "should skip already sent user")
+	})
+
+	t.Run("skips unapproved user", func(t *testing.T) {
+		ctx := context.Background()
+		pool := testDB(ctx, t)
+		b := setupTestBot(t, pool)
+		b.displayLocation = loc
+		mockBot := mocks.NewMockBot()
+		b.messageSender = mockBot
+		b.cfg.WeeklyReportEnabled = true
+		b.cfg.WeeklyReportDay = 1
+		b.cfg.WeeklyReportHour = 9
+		b.cfg.WhitelistedUserIDs = nil
+
+		err := b.userRepo.UpsertUser(ctx, &models.User{
+			ID:        4006,
+			Username:  "stranger",
+			FirstName: "Frank",
+		})
+		require.NoError(t, err)
+
+		sent := make(map[int64]string)
+		b.checkAndSendWeeklyReports(ctx, sent, monday9amUTC)
+
+		require.Equal(t, 0, mockBot.SentMessageCount(), "should skip unapproved user")
+	})
+
+	t.Run("handles send failure gracefully", func(t *testing.T) {
+		ctx := context.Background()
+		pool := testDB(ctx, t)
+		b := setupTestBot(t, pool)
+		b.displayLocation = loc
+		mockBot := mocks.NewMockBot()
+		mockBot.SendMessageError = errors.New("user blocked bot")
+		b.messageSender = mockBot
+		b.cfg.WeeklyReportEnabled = true
+		b.cfg.WeeklyReportDay = 1
+		b.cfg.WeeklyReportHour = 9
+		b.cfg.WhitelistedUserIDs = []int64{4007}
+
+		err := b.userRepo.UpsertUser(ctx, &models.User{
+			ID:        4007,
+			Username:  "blockeduser",
+			FirstName: "Grace",
+		})
+		require.NoError(t, err)
+		err = b.userRepo.UpdateTimezone(ctx, 4007, "Etc/GMT-8")
+		require.NoError(t, err)
+
+		// Create an expense in previous week.
+		prevMonday := time.Date(2026, 4, 27, 10, 0, 0, 0, loc)
+		expense := &models.Expense{
+			UserID:      4007,
+			Amount:      decimal.NewFromFloat(5.00),
+			Currency:    "SGD",
+			Description: "Coffee",
+			Status:      models.ExpenseStatusConfirmed,
+		}
+		err = b.expenseRepo.Create(ctx, expense)
+		require.NoError(t, err)
+		_, err = b.db.Exec(ctx, testUpdateExpenseTimeSQL, prevMonday, expense.ID)
+		require.NoError(t, err)
+
+		sent := make(map[int64]string)
+		b.checkAndSendWeeklyReports(ctx, sent, monday9amUTC)
+
+		_, exists := sent[4007]
+		require.False(t, exists, "should not mark as sent on failure")
+	})
+
+	t.Run("prunes stale entries from sent map", func(t *testing.T) {
+		ctx := context.Background()
+		pool := testDB(ctx, t)
+		b := setupTestBot(t, pool)
+		b.displayLocation = loc
+		mockBot := mocks.NewMockBot()
+		b.messageSender = mockBot
+		b.cfg.WeeklyReportEnabled = true
+		b.cfg.WeeklyReportDay = 1
+		b.cfg.WeeklyReportHour = 9
+		b.cfg.WhitelistedUserIDs = []int64{4008}
+
+		sent := map[int64]string{
+			9001: "2026-04-01", // month ago — should be pruned
+			9002: "2026-04-20", // 2 weeks ago — should survive (cutoff is 14 days)
+			9003: "2026-04-27", // last week — should survive
+		}
+
+		b.checkAndSendWeeklyReports(ctx, sent, monday9amUTC)
+
+		_, has9001 := sent[9001]
+		require.False(t, has9001, "old entry should be pruned")
+		require.Equal(t, "2026-04-20", sent[9002], "entry within 14 days should survive")
+		require.Equal(t, "2026-04-27", sent[9003], "last week's entry should survive")
+	})
+
+	t.Run("falls back to displayLocation when user timezone is empty", func(t *testing.T) {
+		ctx := context.Background()
+		pool := testDB(ctx, t)
+		b := setupTestBot(t, pool)
+		b.displayLocation = loc // GMT+8
+		mockBot := mocks.NewMockBot()
+		b.messageSender = mockBot
+		b.cfg.WeeklyReportEnabled = true
+		b.cfg.WeeklyReportDay = 1
+		b.cfg.WeeklyReportHour = 9
+		b.cfg.WhitelistedUserIDs = []int64{4009}
+
+		err := b.userRepo.UpsertUser(ctx, &models.User{
+			ID:        4009,
+			Username:  "defaulttz",
+			FirstName: "Hank",
+		})
+		require.NoError(t, err)
+		err = b.userRepo.UpdateTimezone(ctx, 4009, "")
+		require.NoError(t, err)
+
+		// Create expense in previous week.
+		prevMonday := time.Date(2026, 4, 27, 10, 0, 0, 0, loc)
+		expense := &models.Expense{
+			UserID:      4009,
+			Amount:      decimal.NewFromFloat(5.00),
+			Currency:    "SGD",
+			Description: "Coffee",
+			Status:      models.ExpenseStatusConfirmed,
+		}
+		err = b.expenseRepo.Create(ctx, expense)
+		require.NoError(t, err)
+		_, err = b.db.Exec(ctx, testUpdateExpenseTimeSQL, prevMonday, expense.ID)
+		require.NoError(t, err)
+
+		sent := make(map[int64]string)
+		b.checkAndSendWeeklyReports(ctx, sent, monday9amUTC)
+
+		require.Equal(t, 1, mockBot.SentMessageCount(), "should fall back to displayLocation and send report")
+	})
+
+	t.Run("per-user timezone: only matching user receives report", func(t *testing.T) {
+		ctx := context.Background()
+		pool := testDB(ctx, t)
+		b := setupTestBot(t, pool)
+		b.displayLocation = time.UTC
+		mockBot := mocks.NewMockBot()
+		b.messageSender = mockBot
+		b.cfg.WeeklyReportEnabled = true
+		b.cfg.WeeklyReportDay = 1  // Monday
+		b.cfg.WeeklyReportHour = 9 // 9 AM
+		b.cfg.WhitelistedUserIDs = []int64{4101, 4102}
+
+		// User in GMT+8: at 01:00 UTC Monday = 09:00 local → matches
+		err := b.userRepo.UpsertUser(ctx, &models.User{
+			ID:        4101,
+			Username:  "sguser",
+			FirstName: "Sg",
+		})
+		require.NoError(t, err)
+		err = b.userRepo.UpdateTimezone(ctx, 4101, "Etc/GMT-8")
+		require.NoError(t, err)
+
+		// User in GMT+5: at 01:00 UTC Monday = 06:00 local → doesn't match
+		err = b.userRepo.UpsertUser(ctx, &models.User{
+			ID:        4102,
+			Username:  "eastuser",
+			FirstName: "East",
+		})
+		require.NoError(t, err)
+		err = b.userRepo.UpdateTimezone(ctx, 4102, "Etc/GMT+5")
+		require.NoError(t, err)
+
+		// Create expense for both users in previous week.
+		prevMonday := time.Date(2026, 4, 27, 10, 0, 0, 0, time.UTC)
+		for _, uid := range []int64{4101, 4102} {
+			expense := &models.Expense{
+				UserID:      uid,
+				Amount:      decimal.NewFromFloat(10.00),
+				Currency:    "SGD",
+				Description: "Lunch",
+				Status:      models.ExpenseStatusConfirmed,
+			}
+			err = b.expenseRepo.Create(ctx, expense)
+			require.NoError(t, err)
+			_, err = b.db.Exec(ctx, testUpdateExpenseTimeSQL, prevMonday, expense.ID)
+			require.NoError(t, err)
+		}
+
+		sent := make(map[int64]string)
+		b.checkAndSendWeeklyReports(ctx, sent, monday9amUTC)
+
+		require.Equal(t, 1, mockBot.SentMessageCount(), "only GMT+8 user should receive report")
+		msg := mockBot.LastSentMessage()
+		require.Equal(t, int64(4101), msg.ChatID)
+	})
+
+	t.Run("sends summary even when tag repository is nil", func(t *testing.T) {
+		ctx := context.Background()
+		pool := testDB(ctx, t)
+		b := setupTestBot(t, pool)
+		b.displayLocation = loc
+		mockBot := mocks.NewMockBot()
+		b.messageSender = mockBot
+		b.tagRepo = nil
+		b.cfg.WeeklyReportEnabled = true
+		b.cfg.WeeklyReportDay = 1
+		b.cfg.WeeklyReportHour = 9
+		b.cfg.WhitelistedUserIDs = []int64{4103}
+
+		err := b.userRepo.UpsertUser(ctx, &models.User{
+			ID:        4103,
+			Username:  "niltagrepo",
+			FirstName: "Nina",
+		})
+		require.NoError(t, err)
+		err = b.userRepo.UpdateTimezone(ctx, 4103, "Etc/GMT-8")
+		require.NoError(t, err)
+
+		prevMonday := time.Date(2026, 4, 27, 10, 0, 0, 0, loc)
+		expense := &models.Expense{
+			UserID:      4103,
+			Amount:      decimal.NewFromFloat(7.25),
+			Currency:    "SGD",
+			Description: "Tea",
+			Status:      models.ExpenseStatusConfirmed,
+		}
+		err = b.expenseRepo.Create(ctx, expense)
+		require.NoError(t, err)
+		_, err = b.db.Exec(ctx, testUpdateExpenseTimeSQL, prevMonday, expense.ID)
+		require.NoError(t, err)
+
+		sent := make(map[int64]string)
+		b.checkAndSendWeeklyReports(ctx, sent, monday9amUTC)
+
+		require.Equal(t, 1, mockBot.SentMessageCount())
+		msg := mockBot.LastSentMessage()
+		require.Contains(t, msg.Text, "Weekly Expenses")
+		require.Contains(t, msg.Text, "Tea")
+	})
+}
+
+func TestGetPreviousWeekRangeAt(t *testing.T) {
+	t.Parallel()
+
+	loc := time.UTC
+
+	t.Run("Monday returns previous week", func(t *testing.T) {
+		t.Parallel()
+		monday := time.Date(2026, 5, 4, 10, 0, 0, 0, loc)
+		start, end := getPreviousWeekRangeAt(monday)
+
+		require.Equal(t, "2026-04-27", start.Format("2006-01-02"))
+		require.Equal(t, "2026-05-04", end.Format("2006-01-02"))
+	})
+
+	t.Run("Wednesday returns same previous week as Monday", func(t *testing.T) {
+		t.Parallel()
+		wednesday := time.Date(2026, 5, 6, 10, 0, 0, 0, loc)
+		monday := time.Date(2026, 5, 4, 10, 0, 0, 0, loc)
+
+		wStart, wEnd := getPreviousWeekRangeAt(wednesday)
+		mStart, mEnd := getPreviousWeekRangeAt(monday)
+
+		require.Equal(t, mStart, wStart)
+		require.Equal(t, mEnd, wEnd)
+	})
+}

--- a/internal/bot/weekly_report_test.go
+++ b/internal/bot/weekly_report_test.go
@@ -448,3 +448,106 @@ func TestGetPreviousWeekRangeAt(t *testing.T) {
 		require.Equal(t, mEnd, wEnd)
 	})
 }
+
+func TestStartWeeklyReportLoop_RunsImmediateCheck(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pool := testDB(ctx, t)
+	b := setupTestBot(t, pool)
+
+	loc := time.FixedZone("GMT+8", 8*60*60)
+	b.displayLocation = loc
+	// Fixed time: Monday 9 AM GMT+8 = 01:00 UTC.
+	fixedNow := time.Date(2026, 5, 4, 1, 0, 0, 0, time.UTC)
+	b.nowFunc = func() time.Time { return fixedNow }
+
+	mockBot := mocks.NewMockBot()
+	b.messageSender = mockBot
+	b.cfg.WeeklyReportEnabled = true
+	b.cfg.WeeklyReportDay = 1  // Monday
+	b.cfg.WeeklyReportHour = 9 // 9 AM
+	b.cfg.WhitelistedUserIDs = []int64{5001}
+
+	err := b.userRepo.UpsertUser(ctx, &models.User{
+		ID:        5001,
+		Username:  "loopcheck",
+		FirstName: "Nora",
+	})
+	require.NoError(t, err)
+	err = b.userRepo.UpdateTimezone(ctx, 5001, "Etc/GMT-8")
+	require.NoError(t, err)
+
+	// Create an expense in the previous week (Apr 27 - May 3).
+	prevMonday := time.Date(2026, 4, 27, 10, 0, 0, 0, loc)
+	expense := &models.Expense{
+		UserID:      5001,
+		Amount:      decimal.NewFromFloat(10.00),
+		Currency:    "SGD",
+		Description: "Lunch",
+		Status:      models.ExpenseStatusConfirmed,
+	}
+	err = b.expenseRepo.Create(ctx, expense)
+	require.NoError(t, err)
+	_, err = b.db.Exec(ctx, testUpdateExpenseTimeSQL, prevMonday, expense.ID)
+	require.NoError(t, err)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		b.startWeeklyReportLoop(ctx)
+	}()
+
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if mockBot.SentMessageCount() > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	cancel()
+	<-done
+
+	require.Equal(t, 1, mockBot.SentMessageCount(), "should send weekly report on immediate startup check")
+	msg := mockBot.LastSentMessage()
+	require.Contains(t, msg.Text, "Weekly Expenses")
+}
+
+func TestSendWeeklySummary_FetchError(t *testing.T) {
+	ctx := context.Background()
+	pool := testDB(ctx, t)
+	b := setupTestBot(t, pool)
+
+	canceledCtx, cancel := context.WithCancel(ctx)
+	cancel()
+
+	err := b.sendWeeklySummary(
+		canceledCtx,
+		&models.User{ID: 5002, FirstName: "Err"},
+		time.Now(),
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to fetch weekly expenses")
+}
+
+func TestCheckAndSendWeeklyReports_FetchUsersError(t *testing.T) {
+	ctx := context.Background()
+	pool := testDB(ctx, t)
+	b := setupTestBot(t, pool)
+	b.cfg.WeeklyReportEnabled = true
+	b.cfg.WeeklyReportDay = 1
+	b.cfg.WeeklyReportHour = 9
+	b.cfg.WhitelistedUserIDs = []int64{5003}
+
+	loc := time.FixedZone("GMT+8", 8*60*60)
+	monday9amUTC := time.Date(2026, 5, 4, 1, 0, 0, 0, time.UTC)
+	b.displayLocation = loc
+
+	canceledCtx, cancel := context.WithCancel(ctx)
+	cancel()
+
+	sent := make(map[int64]string)
+	// Should not panic when fetching users fails.
+	b.checkAndSendWeeklyReports(canceledCtx, sent, monday9amUTC)
+	require.Empty(t, sent)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"slices"
 	"strconv"
@@ -137,12 +138,16 @@ func applyWeeklyReportConfig(cfg *Config) {
 	if dayStr := os.Getenv("WEEKLY_REPORT_DAY"); dayStr != "" {
 		if d, err := strconv.Atoi(dayStr); err == nil && d >= 0 && d <= 6 {
 			cfg.WeeklyReportDay = d
+		} else {
+			log.Printf("invalid WEEKLY_REPORT_DAY %q, using default day %d", dayStr, cfg.WeeklyReportDay)
 		}
 	}
 	cfg.WeeklyReportHour = 9
 	if hourStr := os.Getenv("WEEKLY_REPORT_HOUR"); hourStr != "" {
 		if h, err := strconv.Atoi(hourStr); err == nil && h >= 0 && h <= 23 {
 			cfg.WeeklyReportHour = h
+		} else {
+			log.Printf("invalid WEEKLY_REPORT_HOUR %q, using default hour %d", hourStr, cfg.WeeklyReportHour)
 		}
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -139,6 +139,7 @@ func applyWeeklyReportConfig(cfg *Config) {
 		if d, err := strconv.Atoi(dayStr); err == nil && d >= 0 && d <= 6 {
 			cfg.WeeklyReportDay = time.Weekday(d)
 		} else {
+			//nolint:gosec // env var from deployer; %q safely quotes.
 			log.Printf("invalid WEEKLY_REPORT_DAY %q, using default day %s", dayStr, cfg.WeeklyReportDay)
 		}
 	}
@@ -147,6 +148,7 @@ func applyWeeklyReportConfig(cfg *Config) {
 		if h, err := strconv.Atoi(hourStr); err == nil && h >= 0 && h <= 23 {
 			cfg.WeeklyReportHour = h
 		} else {
+			//nolint:gosec // env var from deployer; %q safely quotes.
 			log.Printf("invalid WEEKLY_REPORT_HOUR %q, using default hour %d", hourStr, cfg.WeeklyReportHour)
 		}
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,6 +32,11 @@ type Config struct {
 	ReminderHour         int
 	ReminderTimezone     string
 
+	// Weekly report configuration.
+	WeeklyReportEnabled bool
+	WeeklyReportDay     int
+	WeeklyReportHour    int
+
 	// OpenTelemetry configuration.
 	OTelEnabled         bool
 	OTelServiceName     string
@@ -59,6 +64,7 @@ func Load() (*Config, error) {
 		return nil, err
 	}
 	applyReminderConfig(cfg)
+	applyWeeklyReportConfig(cfg)
 	applyOTelConfig(cfg)
 	cfg.WhitelistedUserIDs = parseWhitelistedUserIDs(os.Getenv("WHITELISTED_USER_IDS"))
 	cfg.WhitelistedUsernames = parseWhitelistedUsernames(os.Getenv("WHITELISTED_USERNAMES"))
@@ -121,6 +127,22 @@ func applyReminderConfig(cfg *Config) {
 	if tz := os.Getenv("REMINDER_TIMEZONE"); tz != "" {
 		if _, err := time.LoadLocation(tz); err == nil {
 			cfg.ReminderTimezone = tz
+		}
+	}
+}
+
+func applyWeeklyReportConfig(cfg *Config) {
+	cfg.WeeklyReportEnabled = os.Getenv("WEEKLY_REPORT_ENABLED") == envTrue
+	cfg.WeeklyReportDay = 1 // Monday
+	if dayStr := os.Getenv("WEEKLY_REPORT_DAY"); dayStr != "" {
+		if d, err := strconv.Atoi(dayStr); err == nil && d >= 0 && d <= 6 {
+			cfg.WeeklyReportDay = d
+		}
+	}
+	cfg.WeeklyReportHour = 9
+	if hourStr := os.Getenv("WEEKLY_REPORT_HOUR"); hourStr != "" {
+		if h, err := strconv.Atoi(hourStr); err == nil && h >= 0 && h <= 23 {
+			cfg.WeeklyReportHour = h
 		}
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,7 +35,7 @@ type Config struct {
 
 	// Weekly report configuration.
 	WeeklyReportEnabled bool
-	WeeklyReportDay     int
+	WeeklyReportDay     time.Weekday
 	WeeklyReportHour    int
 
 	// OpenTelemetry configuration.
@@ -134,12 +134,12 @@ func applyReminderConfig(cfg *Config) {
 
 func applyWeeklyReportConfig(cfg *Config) {
 	cfg.WeeklyReportEnabled = os.Getenv("WEEKLY_REPORT_ENABLED") == envTrue
-	cfg.WeeklyReportDay = 1 // Monday
+	cfg.WeeklyReportDay = time.Monday
 	if dayStr := os.Getenv("WEEKLY_REPORT_DAY"); dayStr != "" {
 		if d, err := strconv.Atoi(dayStr); err == nil && d >= 0 && d <= 6 {
-			cfg.WeeklyReportDay = d
+			cfg.WeeklyReportDay = time.Weekday(d)
 		} else {
-			log.Printf("invalid WEEKLY_REPORT_DAY %q, using default day %d", dayStr, cfg.WeeklyReportDay)
+			log.Printf("invalid WEEKLY_REPORT_DAY %q, using default day %s", dayStr, cfg.WeeklyReportDay)
 		}
 	}
 	cfg.WeeklyReportHour = 9

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -139,7 +139,6 @@ func applyWeeklyReportConfig(cfg *Config) {
 		if d, err := strconv.Atoi(dayStr); err == nil && d >= 0 && d <= 6 {
 			cfg.WeeklyReportDay = time.Weekday(d)
 		} else {
-			//nolint:gosec // env var from deployer; %q safely quotes.
 			log.Printf("invalid WEEKLY_REPORT_DAY %q, using default day %s", dayStr, cfg.WeeklyReportDay)
 		}
 	}
@@ -148,7 +147,6 @@ func applyWeeklyReportConfig(cfg *Config) {
 		if h, err := strconv.Atoi(hourStr); err == nil && h >= 0 && h <= 23 {
 			cfg.WeeklyReportHour = h
 		} else {
-			//nolint:gosec // env var from deployer; %q safely quotes.
 			log.Printf("invalid WEEKLY_REPORT_HOUR %q, using default hour %d", hourStr, cfg.WeeklyReportHour)
 		}
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -319,10 +319,10 @@ func TestLoad_WeeklyReport(t *testing.T) {
 
 		cfg, err := Load()
 		require.NoError(t, err)
-		require.Equal(t, 3, cfg.WeeklyReportDay)
+		require.Equal(t, time.Wednesday, cfg.WeeklyReportDay)
 	})
 
-	t.Run("defaults WEEKLY_REPORT_DAY to 1 for invalid value", func(t *testing.T) {
+	t.Run("defaults WEEKLY_REPORT_DAY to Monday for invalid value", func(t *testing.T) {
 		t.Setenv(envTelegramKeyVarConfig, testTokenConfig)
 		t.Setenv(envDatabaseURL, testDatabaseURLConfig)
 		t.Setenv(envWhitelistedUserIDs, "123")
@@ -330,10 +330,10 @@ func TestLoad_WeeklyReport(t *testing.T) {
 
 		cfg, err := Load()
 		require.NoError(t, err)
-		require.Equal(t, 1, cfg.WeeklyReportDay)
+		require.Equal(t, time.Monday, cfg.WeeklyReportDay)
 	})
 
-	t.Run("defaults WEEKLY_REPORT_DAY to 1 for non-numeric value", func(t *testing.T) {
+	t.Run("defaults WEEKLY_REPORT_DAY to Monday for non-numeric value", func(t *testing.T) {
 		t.Setenv(envTelegramKeyVarConfig, testTokenConfig)
 		t.Setenv(envDatabaseURL, testDatabaseURLConfig)
 		t.Setenv(envWhitelistedUserIDs, "123")
@@ -341,7 +341,7 @@ func TestLoad_WeeklyReport(t *testing.T) {
 
 		cfg, err := Load()
 		require.NoError(t, err)
-		require.Equal(t, 1, cfg.WeeklyReportDay)
+		require.Equal(t, time.Monday, cfg.WeeklyReportDay)
 	})
 
 	t.Run("parses valid WEEKLY_REPORT_HOUR", func(t *testing.T) {
@@ -388,7 +388,7 @@ func TestLoad_WeeklyReport(t *testing.T) {
 		cfg, err := Load()
 		require.NoError(t, err)
 		require.True(t, cfg.WeeklyReportEnabled)
-		require.Equal(t, 0, cfg.WeeklyReportDay)
+		require.Equal(t, time.Sunday, cfg.WeeklyReportDay)
 		require.Equal(t, 8, cfg.WeeklyReportHour)
 	})
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -278,6 +278,110 @@ func TestLoad_DailyReminder(t *testing.T) {
 	})
 }
 
+func TestLoad_WeeklyReport(t *testing.T) {
+	t.Run("parses WEEKLY_REPORT_ENABLED=true", func(t *testing.T) {
+		t.Setenv(envTelegramKeyVarConfig, testTokenConfig)
+		t.Setenv(envDatabaseURL, testDatabaseURLConfig)
+		t.Setenv(envWhitelistedUserIDs, "123")
+		t.Setenv("WEEKLY_REPORT_ENABLED", "true")
+
+		cfg, err := Load()
+		require.NoError(t, err)
+		require.True(t, cfg.WeeklyReportEnabled)
+	})
+
+	t.Run("defaults WEEKLY_REPORT_ENABLED to false", func(t *testing.T) {
+		t.Setenv(envTelegramKeyVarConfig, testTokenConfig)
+		t.Setenv(envDatabaseURL, testDatabaseURLConfig)
+		t.Setenv(envWhitelistedUserIDs, "123")
+
+		cfg, err := Load()
+		require.NoError(t, err)
+		require.False(t, cfg.WeeklyReportEnabled)
+	})
+
+	t.Run("parses valid WEEKLY_REPORT_DAY", func(t *testing.T) {
+		t.Setenv(envTelegramKeyVarConfig, testTokenConfig)
+		t.Setenv(envDatabaseURL, testDatabaseURLConfig)
+		t.Setenv(envWhitelistedUserIDs, "123")
+		t.Setenv("WEEKLY_REPORT_DAY", "3")
+
+		cfg, err := Load()
+		require.NoError(t, err)
+		require.Equal(t, 3, cfg.WeeklyReportDay)
+	})
+
+	t.Run("defaults WEEKLY_REPORT_DAY to 1 for invalid value", func(t *testing.T) {
+		t.Setenv(envTelegramKeyVarConfig, testTokenConfig)
+		t.Setenv(envDatabaseURL, testDatabaseURLConfig)
+		t.Setenv(envWhitelistedUserIDs, "123")
+		t.Setenv("WEEKLY_REPORT_DAY", "7")
+
+		cfg, err := Load()
+		require.NoError(t, err)
+		require.Equal(t, 1, cfg.WeeklyReportDay)
+	})
+
+	t.Run("defaults WEEKLY_REPORT_DAY to 1 for non-numeric value", func(t *testing.T) {
+		t.Setenv(envTelegramKeyVarConfig, testTokenConfig)
+		t.Setenv(envDatabaseURL, testDatabaseURLConfig)
+		t.Setenv(envWhitelistedUserIDs, "123")
+		t.Setenv("WEEKLY_REPORT_DAY", "abc")
+
+		cfg, err := Load()
+		require.NoError(t, err)
+		require.Equal(t, 1, cfg.WeeklyReportDay)
+	})
+
+	t.Run("parses valid WEEKLY_REPORT_HOUR", func(t *testing.T) {
+		t.Setenv(envTelegramKeyVarConfig, testTokenConfig)
+		t.Setenv(envDatabaseURL, testDatabaseURLConfig)
+		t.Setenv(envWhitelistedUserIDs, "123")
+		t.Setenv("WEEKLY_REPORT_HOUR", "9")
+
+		cfg, err := Load()
+		require.NoError(t, err)
+		require.Equal(t, 9, cfg.WeeklyReportHour)
+	})
+
+	t.Run("defaults WEEKLY_REPORT_HOUR to 9 for invalid value", func(t *testing.T) {
+		t.Setenv(envTelegramKeyVarConfig, testTokenConfig)
+		t.Setenv(envDatabaseURL, testDatabaseURLConfig)
+		t.Setenv(envWhitelistedUserIDs, "123")
+		t.Setenv("WEEKLY_REPORT_HOUR", "25")
+
+		cfg, err := Load()
+		require.NoError(t, err)
+		require.Equal(t, 9, cfg.WeeklyReportHour)
+	})
+
+	t.Run("defaults WEEKLY_REPORT_HOUR to 9 for non-numeric value", func(t *testing.T) {
+		t.Setenv(envTelegramKeyVarConfig, testTokenConfig)
+		t.Setenv(envDatabaseURL, testDatabaseURLConfig)
+		t.Setenv(envWhitelistedUserIDs, "123")
+		t.Setenv("WEEKLY_REPORT_HOUR", "abc")
+
+		cfg, err := Load()
+		require.NoError(t, err)
+		require.Equal(t, 9, cfg.WeeklyReportHour)
+	})
+
+	t.Run("parses all weekly report config together", func(t *testing.T) {
+		t.Setenv(envTelegramKeyVarConfig, testTokenConfig)
+		t.Setenv(envDatabaseURL, testDatabaseURLConfig)
+		t.Setenv(envWhitelistedUserIDs, "123")
+		t.Setenv("WEEKLY_REPORT_ENABLED", "true")
+		t.Setenv("WEEKLY_REPORT_DAY", "0")
+		t.Setenv("WEEKLY_REPORT_HOUR", "8")
+
+		cfg, err := Load()
+		require.NoError(t, err)
+		require.True(t, cfg.WeeklyReportEnabled)
+		require.Equal(t, 0, cfg.WeeklyReportDay)
+		require.Equal(t, 8, cfg.WeeklyReportHour)
+	})
+}
+
 func TestLoad_Validation(t *testing.T) {
 	t.Run("fails when TELEGRAM_BOT_TOKEN is missing", func(t *testing.T) {
 		t.Setenv(envTelegramKeyVarConfig, "")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -290,6 +290,17 @@ func TestLoad_WeeklyReport(t *testing.T) {
 		require.True(t, cfg.WeeklyReportEnabled)
 	})
 
+	t.Run("parses WEEKLY_REPORT_ENABLED=false", func(t *testing.T) {
+		t.Setenv(envTelegramKeyVarConfig, testTokenConfig)
+		t.Setenv(envDatabaseURL, testDatabaseURLConfig)
+		t.Setenv(envWhitelistedUserIDs, "123")
+		t.Setenv("WEEKLY_REPORT_ENABLED", "false")
+
+		cfg, err := Load()
+		require.NoError(t, err)
+		require.False(t, cfg.WeeklyReportEnabled)
+	})
+
 	t.Run("defaults WEEKLY_REPORT_ENABLED to false", func(t *testing.T) {
 		t.Setenv(envTelegramKeyVarConfig, testTokenConfig)
 		t.Setenv(envDatabaseURL, testDatabaseURLConfig)


### PR DESCRIPTION
## Summary by Sourcery

Add configurable weekly expense report summaries sent by a background loop based on per-user timezone.

New Features:
- Introduce weekly report configuration options (enable flag, day, hour) driven by environment variables.
- Add a background weekly report loop that sends previous-week expense summaries to authorized users at their configured local time.

Enhancements:
- Extend date range utilities to compute the previous week's range for reporting.

Tests:
- Add configuration tests for weekly report settings and comprehensive tests covering weekly report sending behavior, edge cases, and timezone handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated weekly expense reports delivered to users on a configurable day/hour with duplicate-prevention and enable/disable switch
  * Daily "today's expenses" summary now shows per-currency breakdowns

* **Tests**
  * Comprehensive tests for weekly report sending, previous-week date calculations, configuration parsing, and per-currency summation behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->