### PR TITLE
Feature spending reflection

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A Telegram bot for tracking personal expenses with multi-currency support, AI-po
 - **Category Management**: Organize expenses with predefined or custom categories
 - **Expense Queries**: View expenses by time period (today, this week, recent)
 - **Expense Editing**: Modify or delete existing expenses with inline buttons
+- **Spending Reflection**: Review expenses with `/review` and summarize habits with `/habit`
 - **User Whitelisting**: Control who can access your bot (by user ID or username)
 - **Expense Tags**: Label expenses with hashtags like `#work`, `#travel` for flexible cross-category organization
 - **Category Rename/Delete**: Rename categories with `/renamecategory Old -> New` and delete with `/deletecategory`
@@ -201,6 +202,8 @@ go run main.go
 | `/list` | Show recent expenses (last 10) | `/list` |
 | `/today` | Show today's expenses with total | `/today` |
 | `/week` | Show this week's expenses with total | `/week` |
+| `/review` | Review confirmed expenses one at a time | `/review` |
+| `/habit [week\|month\|90d]` | Summarize spending reflection habits | `/habit month` |
 | `/category <name>` | Filter expenses by category | `/category Food - Dining Out` |
 | `/report week` | Generate weekly expense report (CSV) | `/report week` |
 | `/report month` | Generate monthly expense report (CSV) | `/report month` |
@@ -518,6 +521,9 @@ openssl rand -hex 32
 - `category_id` (INT, FK) - References categories
 - `receipt_file_id` (TEXT) - Telegram file ID
 - `status` (TEXT) - 'draft' or 'confirmed'
+- `worth_it` (BOOL) - Spending reflection answer
+- `spend_driver` (TEXT) - Reason selected for the reflection
+- `reviewed_at` (TIMESTAMP) - When the reflection was recorded
 - `created_at`, `updated_at` - Timestamps
 
 **Indexes**: user_id, created_at, category_id, status

--- a/docs/SPENDING_REFLECTION_PLAN.md
+++ b/docs/SPENDING_REFLECTION_PLAN.md
@@ -1,0 +1,439 @@
+# Spending Reflection Feature Plan
+
+## Goal
+
+Build a Peek-inspired spending reflection feature for the Telegram bot.
+Instead of only categorizing expenses by where money went, the bot should help
+users understand whether each expense felt worth it and what drove the purchase.
+
+Peek's public product framing centers on a simple per-transaction question:
+"worth it, or not", spending drivers such as convenience, ritual, comfort, and
+impulse, then narrative recaps and realistic plans based on actual spending plus
+the user's own evaluation.
+
+Reference: https://peek.money/
+
+## Product Scope
+
+### MVP Commands
+
+Add two user-facing commands:
+
+- `/review` - Review recent unreviewed expenses.
+- `/habit [week|month|90d]` - Show a spending reflection recap.
+
+Default `/habit` period should be `month`.
+
+### Review Flow
+
+When a user runs `/review`, show one unreviewed confirmed expense at a time with
+inline buttons:
+
+- Worth it
+- Not worth it
+- Skip
+
+After the user chooses worth it or not worth it, ask what drove the purchase:
+
+- Necessity
+- Convenience
+- Ritual
+- Comfort
+- Celebration
+- Social
+- Gift
+- Self-care
+- Hobby
+- Impulse
+- Productivity
+- Other
+
+The bot should save the reflection and move to the next unreviewed expense.
+
+### Inline Reflection After Save
+
+After a new expense is saved, include a small reflection entry point in every
+expense confirmation message: structured `/add`, free-text entry, receipt OCR,
+voice input, and inline edited confirmation where appropriate. This should not
+interrupt the fast expense entry flow. Confirm that the final keyboard remains
+readable beside existing edit and delete actions; a third row is acceptable if
+it keeps the main actions clear.
+
+Example buttons:
+
+- Worth it
+- Not worth it
+- Later
+
+If the user chooses worth it or not worth it, ask for the spending driver using
+the same driver buttons as `/review`. If the user taps Later, leave the expense
+unreviewed and edit the message keyboard to remove the reflection buttons while
+keeping the normal confirmation text intact.
+
+### Habit Recap
+
+`/habit month` should generate a concise, narrative text recap. For the MVP,
+do not convert currencies in the read path. Show totals per currency and keep
+category calculations separated by currency where spend totals matter.
+
+```text
+📈 Spending Reflection - Last 30 days
+
+Reviewed: 23/41 expenses
+Worth-it rate: 74%
+Worth-it spend:
+  SGD: S$612.40
+  USD: $42.00
+Not-worth-it spend:
+  SGD: S$119.80
+
+Top driver: Convenience
+Best-value category: Food - Grocery
+Most regretted category: Shopping
+Weekday pattern: Friday had the most not-worth-it spending
+
+Insight: Small convenience purchases added up most often when you were busy.
+```
+
+The recap should be descriptive, not judgmental. Avoid telling the user what
+they should do. Use language like "pattern", "often", and "looks like" instead
+of "bad", "waste", or "problem".
+
+## Data Model
+
+Append nullable reflection columns to the migration statement slice in
+`internal/database/migrations.go`:
+
+```sql
+ALTER TABLE expenses ADD COLUMN IF NOT EXISTS worth_it BOOLEAN;
+ALTER TABLE expenses ADD COLUMN IF NOT EXISTS spend_driver TEXT;
+ALTER TABLE expenses ADD COLUMN IF NOT EXISTS reviewed_at TIMESTAMPTZ;
+```
+
+Update `models.Expense` with:
+
+```go
+WorthIt     *bool
+SpendDriver *string
+ReviewedAt  *time.Time
+```
+
+Keep the fields nullable so old expenses are valid and users can skip review.
+Do not model `spend_driver` as a plain string unless every query uses
+`COALESCE` to an empty string; pgx cannot scan SQL NULL into a Go string.
+
+## Repository Changes
+
+Extend `ExpenseRepository` with:
+
+```go
+UpdateReflection(
+    ctx context.Context,
+    expenseID int,
+    userID int64,
+    worthIt *bool,
+    driver string,
+) error
+
+GetUnreviewedByUserID(
+    ctx context.Context,
+    userID int64,
+    limit int,
+) ([]models.Expense, error)
+
+GetNextUnreviewedByUserID(
+    ctx context.Context,
+    userID int64,
+    afterExpenseID int,
+) (*models.Expense, error)
+
+GetReviewedByUserIDAndDateRange(
+    ctx context.Context,
+    userID int64,
+    startDate time.Time,
+    endDate time.Time,
+) ([]models.Expense, error)
+```
+
+Repository behavior:
+
+- Only operate on `status = 'confirmed'`.
+- Scope `UpdateReflection` by both `id` and `user_id`. Existing generic
+  `Update` and `Delete` methods currently scope by `id`; tightening those is
+  worth a separate hardening change but is outside this feature MVP.
+- Treat skipped expenses as still unreviewed for future sessions, but do not
+  re-serve the same skipped expense in the current callback flow.
+- Join categories in the same way existing expense list queries do.
+- `UpdateReflection` should set `reviewed_at = NOW()` in SQL rather than
+  accepting a timestamp from Go.
+- `UpdateReflection` should write SQL NULL for an empty driver string, not an
+  empty text value, so it round-trips consistently with `SpendDriver *string`.
+- Reflection queries must not reuse `scanExpenses` unchanged. Either update
+  `scanExpenses` and add `worth_it`, `spend_driver`, and `reviewed_at` to
+  every existing expense SELECT list, or create a separate
+  `scanExpensesWithReflection` helper for the new queries. The separate helper
+  is lower risk for the MVP.
+- Scan nullable reflection columns into pointer fields or nullable locals.
+
+`GetNextUnreviewedByUserID` should prevent the skip flow from looping on the
+same row. Use the current expense as a cursor and return the next unreviewed
+expense after it in the same stable ordering used by `GetUnreviewedByUserID`
+(`created_at DESC, id DESC`). If the skipped expense is the last unreviewed
+expense, the handler should show `No more expenses to review.`
+
+## Bot Changes
+
+### Command Registration
+
+Update bot command registration in `internal/bot/bot.go`:
+
+- Add `/review` with description `Review recent expenses`.
+- Add `/habit` with description `Show spending reflection recap`.
+
+Register handlers:
+
+- `/review` -> `handleReview`
+- `/habit` -> `handleHabit`
+
+### Help Text
+
+Update `/help` in `internal/bot/handlers_commands.go` with a new section:
+
+```text
+Spending Reflection:
+• /review - Mark recent expenses as worth it or not worth it
+• /habit [week|month|90d] - Show your spending reflection recap
+```
+
+### New Handler File
+
+Create `internal/bot/handlers_habit.go` for:
+
+- `handleReview`
+- `handleReviewCore`
+- `handleHabit`
+- `handleHabitCore`
+- callback handling for worth-it and driver buttons
+- message formatting helpers
+
+Callback prefixes should be explicit and stable:
+
+- `review_worth_`
+- `review_not_worth_`
+- `review_skip_`
+- `review_driver_`
+
+Prefer registering one `review_` callback prefix in `internal/bot/bot.go` using
+`HandlerTypeCallbackQueryData` and `MatchTypePrefix`, then dispatch internally
+with `strings.HasPrefix`. Registering each concrete prefix separately also
+works, but one prefix keeps registration boilerplate smaller.
+
+The callback payload should include all state needed to continue the flow. Do
+not use the in-memory `pendingEdits` map for this feature. It is keyed by chat
+ID, lost on restart, and unnecessary here.
+
+Recommended callback data:
+
+```text
+review_worth_<expenseID>
+review_not_worth_<expenseID>
+review_skip_<expenseID>
+review_driver_<expenseID>_<0|1>_<driverIdx>
+```
+
+Use `0` for not worth it and `1` for worth it. Use a stable numeric driver
+index rather than the driver label, because labels can contain hyphens or other
+delimiters. The driver list order becomes an append-only contract: add new
+drivers to the end and do not reorder existing entries, otherwise old callback
+messages may decode to a different driver. These payloads are well under the
+Telegram callback data limit of 64 bytes for normal integer IDs.
+
+When parsing callback data, prefer `strings.TrimPrefix` for each registered
+prefix and split only the remaining payload. Avoid relying on fixed indexes
+from `strings.Split(data, "_")` over the full callback string because the
+prefixes themselves contain underscores.
+
+### Analyzer File
+
+Create `internal/bot/habit_analyzer.go` for pure business logic.
+
+Suggested types:
+
+```go
+type SpendingDriver string
+
+type HabitSummary struct {
+    PeriodLabel string
+    ReviewedCount int
+    TotalCount int
+    WorthItCount int
+    NotWorthItCount int
+    WorthItByCurrency map[string]decimal.Decimal
+    NotWorthItByCurrency map[string]decimal.Decimal
+    WorthItByCategory map[string]map[string]decimal.Decimal
+    NotWorthItByCategory map[string]map[string]decimal.Decimal
+    TopDriver SpendingDriver
+    BestValueCategory string
+    MostRegrettedCategory string
+    BusiestNotWorthItWeekday time.Weekday
+    Insight string
+}
+```
+
+Use `github.com/shopspring/decimal` for all money totals.
+
+Keep the analyzer deterministic:
+
+- Sort ties alphabetically.
+- For weekdays, sort by count, then weekday order.
+- For empty data, return a clear empty summary instead of an error.
+- Apply a minimum reviewed-sample guard before naming "best-value" or
+  "most-regretted" categories. A category with only one reviewed expense should
+  not win these labels unless there is no stronger candidate.
+
+Category scoring rules:
+
+- Best-value category: among categories with at least two reviewed expenses,
+  choose the highest worth-it rate. Tie-break by higher worth-it count, then
+  alphabetical category name.
+- Most-regretted category: among categories with at least two reviewed expenses,
+  choose the highest not-worth-it rate. Tie-break by higher not-worth-it count,
+  then alphabetical category name.
+- If no category reaches the minimum sample size, omit the category label or use
+  `Not enough reviewed category data yet.`
+
+For MVP category totals, keep maps keyed by currency first and category second,
+for example `map["SGD"]["Food - Grocery"] = decimal.NewFromFloat(120.50)`.
+This avoids invalid cross-currency sums. A future version may convert all spend
+to the user default currency before analysis.
+
+## Period Semantics
+
+Use existing timezone-aware helpers where possible and add a helper for the
+rolling window:
+
+```go
+func getRollingDayRangeAt(current time.Time, days int) (time.Time, time.Time)
+```
+
+`90d` should call this helper with `days = 90`.
+
+- `week` uses the current week from Monday to Sunday.
+- `month` uses the current calendar month.
+- `90d` uses a rolling 90-day window ending at `now`.
+
+For previous-period comparison:
+
+- `week`: previous calendar week.
+- `month`: previous calendar month.
+- `90d`: previous rolling 90 days.
+
+Because this is a personal reflection feature, `/habit` should use
+`b.userLocation(user.Timezone)`, as daily reminders and weekly reports do. This
+reuses the existing empty-or-invalid-timezone fallback to `b.displayLocation`
+instead of reimplementing that logic.
+
+## Insight Rules
+
+The MVP does not need Gemini. Generate deterministic insights from reviewed
+data:
+
+- If no reviewed expenses: ask the user to run `/review`.
+- If worth-it rate is high: mention the strongest positive pattern.
+- If not-worth-it spend is concentrated in one category: mention that category.
+- If not-worth-it spend is concentrated on one weekday: mention the weekday.
+- If no strong pattern exists: report the top driver and worth-it rate.
+- If multiple currencies are present, mention that spend totals are grouped by
+  currency.
+
+Example:
+
+```text
+Insight: Your not-worth-it spending was mostly Shopping on Fridays.
+```
+
+## Tests
+
+### Unit Tests
+
+Add tests for `habit_analyzer.go`:
+
+- Empty expense list.
+- All unreviewed expenses.
+- Mixed worth-it and not-worth-it expenses.
+- Multiple currencies produce separate currency totals and do not cross-sum.
+- Category totals are grouped by currency first, then category.
+- Nil category uses the existing `categoryUncategorized` constant rather than
+  hardcoding a separate string.
+- Tie-breaking is deterministic.
+- Weekday pattern uses expense `CreatedAt` in the selected user timezone.
+
+### Repository Tests
+
+Add tests in `internal/repository/expense_repository_test.go` or a dedicated
+file:
+
+- `UpdateReflection` updates only the owner's expense.
+- `GetUnreviewedByUserID` returns only confirmed unreviewed expenses.
+- `GetReviewedByUserIDAndDateRange` filters by user, date range, status, and
+  non-null `reviewed_at`.
+- Draft expenses are excluded.
+- Nullable `spend_driver`, `worth_it`, and `reviewed_at` scan without errors.
+- Reflection queries use `scanExpensesWithReflection` or an updated shared
+  scanner with matching SELECT columns.
+
+Database tests should not use `t.Parallel()`.
+
+Add migration tests that assert the three new columns exist. The existing
+migration tests check column existence rather than strict column counts, so new
+columns should not break them.
+
+### Handler Tests
+
+Add bot handler tests:
+
+- `/review` with no expenses.
+- `/review` with unreviewed expenses sends reflection buttons.
+- Worth-it callback asks for driver using callback-encoded state.
+- Driver callback saves reflection using the encoded expense ID, worth flag, and
+  driver index.
+- Skip callback advances to the next unreviewed expense instead of re-serving
+  the skipped one.
+- `/habit` default period works.
+- `/habit invalid` returns usage.
+- `/habit month` with no reviewed expenses asks the user to review expenses.
+- `/habit` arg parsing uses `extractCommandArgs`.
+
+## Documentation Updates
+
+Update `README.md`:
+
+- Feature list.
+- Basic commands table.
+- Usage section for `/review` and `/habit`.
+- Database schema section with reflection fields.
+
+## Verification
+
+Run the required project checks:
+
+```bash
+mise run fmt
+mise run test
+mise run test-coverage
+mise run test-race
+mise run test-integration
+```
+
+Coverage must stay at or above 50%.
+
+## Future Extensions
+
+After the MVP is stable:
+
+- Scheduled monthly reflection recap.
+- User-configurable driver list.
+- Optional Gemini-generated narrative recap from deterministic summary data.
+- Monthly "realistic caps" based on worth-it spend, not total spend.
+- Charts comparing worth-it and not-worth-it spend by category.
+- A skipped-review state if users want to permanently ignore certain expenses.

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -247,6 +247,8 @@ func (b *Bot) registerCommands(ctx context.Context) {
 	commands := []tgmodels.BotCommand{
 		{Command: "add", Description: "Add an expense"},
 		{Command: "list", Description: "Show recent expenses"},
+		{Command: "review", Description: "Review recent spending"},
+		{Command: "habit", Description: "Show spending reflection summary"},
 		{Command: "today", Description: "Show today's expenses"},
 		{Command: "week", Description: "Show this week's expenses"},
 		{Command: "category", Description: "Filter expenses by category"},
@@ -325,6 +327,8 @@ func (b *Bot) registerHandlers() {
 	b.bot.RegisterHandler(bot.HandlerTypeMessageText, "/categories", bot.MatchTypePrefix, b.handleCategories)
 	b.bot.RegisterHandler(bot.HandlerTypeMessageText, "/add", bot.MatchTypePrefix, b.handleAdd)
 	b.bot.RegisterHandler(bot.HandlerTypeMessageText, "/list", bot.MatchTypePrefix, b.handleList)
+	b.bot.RegisterHandler(bot.HandlerTypeMessageText, "/review", bot.MatchTypePrefix, b.handleReview)
+	b.bot.RegisterHandler(bot.HandlerTypeMessageText, "/habit", bot.MatchTypePrefix, b.handleHabit)
 	b.bot.RegisterHandler(bot.HandlerTypeMessageText, "/today", bot.MatchTypePrefix, b.handleToday)
 	b.bot.RegisterHandler(bot.HandlerTypeMessageText, "/week", bot.MatchTypePrefix, b.handleWeek)
 	b.bot.RegisterHandler(bot.HandlerTypeMessageText, "/category", bot.MatchTypePrefix, b.handleCategory)
@@ -358,6 +362,7 @@ func (b *Bot) registerHandlers() {
 	b.bot.RegisterHandler(bot.HandlerTypeCallbackQueryData, "delete_expense_", bot.MatchTypePrefix, b.handleExpenseActionCallback)
 	b.bot.RegisterHandler(bot.HandlerTypeCallbackQueryData, "confirm_delete_", bot.MatchTypePrefix, b.handleConfirmDeleteCallback)
 	b.bot.RegisterHandler(bot.HandlerTypeCallbackQueryData, "back_to_expense_", bot.MatchTypePrefix, b.handleBackToExpenseCallback)
+	b.bot.RegisterHandler(bot.HandlerTypeCallbackQueryData, "review_", bot.MatchTypePrefix, b.handleReviewCallback)
 }
 
 // isAuthorized checks if a user is a superadmin or a DB-approved user.

--- a/internal/bot/date_range.go
+++ b/internal/bot/date_range.go
@@ -65,6 +65,18 @@ func getMonthDateRangeAt(current time.Time) (time.Time, time.Time) {
 	return startOfMonth, endOfMonth
 }
 
+// getRollingDayRangeAt returns the trailing day range as [start, end).
+// current must already be in the desired display location.
+func getRollingDayRangeAt(current time.Time, days int) (time.Time, time.Time) {
+	if days < 1 {
+		days = 1
+	}
+	end := current
+	start := end.AddDate(0, 0, -days)
+
+	return start, end
+}
+
 // getPreviousWeekRangeAt returns the previous week's range as [start, end).
 // On Monday this returns [last Monday, this Monday). On other days this
 // returns the week before the current week. current must already be in the

--- a/internal/bot/date_range_rolling_test.go
+++ b/internal/bot/date_range_rolling_test.go
@@ -1,0 +1,29 @@
+package bot
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetRollingDayRangeAt(t *testing.T) {
+	t.Parallel()
+
+	current := time.Date(2026, 6, 16, 12, 0, 0, 0, time.UTC)
+
+	t.Run("90 day window ends at current", func(t *testing.T) {
+		t.Parallel()
+		start, end := getRollingDayRangeAt(current, 90)
+		require.Equal(t, current, end)
+		require.Equal(t, current.AddDate(0, 0, -90), start)
+		require.Equal(t, 90*24*time.Hour, end.Sub(start))
+	})
+
+	t.Run("non-positive days clamps to one day", func(t *testing.T) {
+		t.Parallel()
+		start, end := getRollingDayRangeAt(current, 0)
+		require.Equal(t, current, end)
+		require.Equal(t, current.AddDate(0, 0, -1), start)
+	})
+}

--- a/internal/bot/date_range_rolling_test.go
+++ b/internal/bot/date_range_rolling_test.go
@@ -11,19 +11,34 @@ func TestGetRollingDayRangeAt(t *testing.T) {
 	t.Parallel()
 
 	current := time.Date(2026, 6, 16, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name      string
+		days      int
+		wantStart time.Time
+		wantEnd   time.Time
+	}{
+		{
+			name:      "90 day window ends at current",
+			days:      90,
+			wantStart: current.AddDate(0, 0, -90),
+			wantEnd:   current,
+		},
+		{
+			name:      "non-positive days clamps to one day",
+			days:      0,
+			wantStart: current.AddDate(0, 0, -1),
+			wantEnd:   current,
+		},
+	}
 
-	t.Run("90 day window ends at current", func(t *testing.T) {
-		t.Parallel()
-		start, end := getRollingDayRangeAt(current, 90)
-		require.Equal(t, current, end)
-		require.Equal(t, current.AddDate(0, 0, -90), start)
-		require.Equal(t, 90*24*time.Hour, end.Sub(start))
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	t.Run("non-positive days clamps to one day", func(t *testing.T) {
-		t.Parallel()
-		start, end := getRollingDayRangeAt(current, 0)
-		require.Equal(t, current, end)
-		require.Equal(t, current.AddDate(0, 0, -1), start)
-	})
+			start, end := getRollingDayRangeAt(current, tt.days)
+			require.Equal(t, tt.wantEnd, end)
+			require.Equal(t, tt.wantStart, start)
+			require.Equal(t, end.Sub(start), tt.wantEnd.Sub(tt.wantStart))
+		})
+	}
 }

--- a/internal/bot/habit_analyzer.go
+++ b/internal/bot/habit_analyzer.go
@@ -1,22 +1,23 @@
 package bot
 
 import (
-	"sort"
+	"cmp"
+	"slices"
 	"time"
 
 	"github.com/shopspring/decimal"
 	appmodels "gitlab.com/yelinaung/expense-bot/internal/models"
 )
 
-type SpendingDriver string
+type spendingDriver string
 
 const (
 	minCategoryReflectionSample = 2
-	spendingDriverOther         = SpendingDriver("Other")
+	spendingDriverOther         = spendingDriver("Other")
 )
 
 // Keep this list append-only and in stable order because callbacks encode indices.
-var spendingDrivers = []SpendingDriver{
+var spendingDrivers = []spendingDriver{
 	"Necessity",
 	"Convenience",
 	"Ritual",
@@ -31,22 +32,19 @@ var spendingDrivers = []SpendingDriver{
 	spendingDriverOther,
 }
 
-type HabitSummary struct {
-	PeriodLabel                     string
-	TotalCount                      int
-	ReviewedCount                   int
-	WorthItCount                    int
-	NotWorthItCount                 int
-	WorthItByCurrency               map[string]decimal.Decimal
-	NotWorthItByCurrency            map[string]decimal.Decimal
-	WorthItByCategoryAndCurrency    map[string]map[string]decimal.Decimal
-	NotWorthItByCategoryAndCurrency map[string]map[string]decimal.Decimal
-	TopDriver                       SpendingDriver
-	BestValueCategory               string
-	MostRegrettedCategory           string
-	BusiestNotWorthItWeekday        time.Weekday
-	HasBusiestNotWorthItWeekday     bool
-	Insight                         string
+type habitSummary struct {
+	PeriodLabel                 string
+	TotalCount                  int
+	ReviewedCount               int
+	WorthItCount                int
+	NotWorthItCount             int
+	WorthItByCurrency           map[string]decimal.Decimal
+	NotWorthItByCurrency        map[string]decimal.Decimal
+	TopDriver                   spendingDriver
+	BestValueCategory           string
+	MostRegrettedCategory       string
+	BusiestNotWorthItWeekday    time.Weekday
+	HasBusiestNotWorthItWeekday bool
 }
 
 type categoryReflectionStats struct {
@@ -55,51 +53,53 @@ type categoryReflectionStats struct {
 	notWorth int
 }
 
-func AnalyzeExpenseHabit(
-	allExpenses []appmodels.Expense,
+type categoryRank struct {
+	name        string
+	rate        float64
+	targetCount int
+}
+
+func analyzeExpenseHabit(
+	totalCount int,
 	reviewedExpenses []appmodels.Expense,
 	loc *time.Location,
 	periodLabel string,
-) HabitSummary {
+) habitSummary {
 	loc = normalizeLocation(loc)
-	summary := HabitSummary{
-		PeriodLabel:                     periodLabel,
-		TotalCount:                      len(allExpenses),
-		WorthItByCurrency:               make(map[string]decimal.Decimal),
-		NotWorthItByCurrency:            make(map[string]decimal.Decimal),
-		WorthItByCategoryAndCurrency:    make(map[string]map[string]decimal.Decimal),
-		NotWorthItByCategoryAndCurrency: make(map[string]map[string]decimal.Decimal),
+	summary := habitSummary{
+		PeriodLabel:          periodLabel,
+		TotalCount:           totalCount,
+		WorthItByCurrency:    make(map[string]decimal.Decimal),
+		NotWorthItByCurrency: make(map[string]decimal.Decimal),
 	}
 
-	driverCounts := make(map[SpendingDriver]int)
+	driverCounts := make(map[spendingDriver]int)
 	categoryStats := make(map[string]categoryReflectionStats)
 	weekdayCounts := make(map[time.Weekday]int)
 
 	for i := range reviewedExpenses {
-		expense := reviewedExpenses[i]
+		expense := &reviewedExpenses[i]
 		if expense.WorthIt == nil {
 			continue
 		}
 
 		summary.ReviewedCount++
-		categoryName := habitCategoryName(&expense)
+		categoryName := habitCategoryName(expense)
 		stats := categoryStats[categoryName]
 		stats.reviewed++
 
 		if expense.SpendDriver != nil && *expense.SpendDriver != "" {
-			driverCounts[SpendingDriver(*expense.SpendDriver)]++
+			driverCounts[spendingDriver(*expense.SpendDriver)]++
 		}
 
 		if *expense.WorthIt {
 			summary.WorthItCount++
 			stats.worth++
 			summary.WorthItByCurrency[expense.Currency] = summary.WorthItByCurrency[expense.Currency].Add(expense.Amount)
-			addCategoryCurrencyTotal(summary.WorthItByCategoryAndCurrency, categoryName, expense.Currency, expense.Amount)
 		} else {
 			summary.NotWorthItCount++
 			stats.notWorth++
 			summary.NotWorthItByCurrency[expense.Currency] = summary.NotWorthItByCurrency[expense.Currency].Add(expense.Amount)
-			addCategoryCurrencyTotal(summary.NotWorthItByCategoryAndCurrency, categoryName, expense.Currency, expense.Amount)
 			weekdayCounts[expense.CreatedAt.In(loc).Weekday()]++
 		}
 
@@ -110,7 +110,6 @@ func AnalyzeExpenseHabit(
 	summary.BestValueCategory = bestValueCategory(categoryStats)
 	summary.MostRegrettedCategory = mostRegrettedCategory(categoryStats)
 	summary.BusiestNotWorthItWeekday, summary.HasBusiestNotWorthItWeekday = busiestWeekday(weekdayCounts)
-	summary.Insight = buildHabitInsight(&summary)
 
 	return summary
 }
@@ -122,20 +121,8 @@ func habitCategoryName(expense *appmodels.Expense) string {
 	return categoryUncategorized
 }
 
-func addCategoryCurrencyTotal(
-	totals map[string]map[string]decimal.Decimal,
-	categoryName string,
-	currency string,
-	amount decimal.Decimal,
-) {
-	if totals[categoryName] == nil {
-		totals[categoryName] = make(map[string]decimal.Decimal)
-	}
-	totals[categoryName][currency] = totals[categoryName][currency].Add(amount)
-}
-
-func topSpendingDriver(counts map[SpendingDriver]int) SpendingDriver {
-	var top SpendingDriver
+func topSpendingDriver(counts map[spendingDriver]int) spendingDriver {
+	var top spendingDriver
 	bestCount := 0
 	for driver, count := range counts {
 		if count > bestCount || (count == bestCount && (top == "" || string(driver) < string(top))) {
@@ -155,30 +142,32 @@ func mostRegrettedCategory(stats map[string]categoryReflectionStats) string {
 }
 
 func rankedCategory(stats map[string]categoryReflectionStats, numerator func(categoryReflectionStats) int) string {
-	categories := make([]string, 0, len(stats))
+	ranks := make([]categoryRank, 0, len(stats))
 	for categoryName, stat := range stats {
 		if stat.reviewed >= minCategoryReflectionSample {
-			categories = append(categories, categoryName)
+			targetCount := numerator(stat)
+			ranks = append(ranks, categoryRank{
+				name:        categoryName,
+				rate:        float64(targetCount) / float64(stat.reviewed),
+				targetCount: targetCount,
+			})
 		}
 	}
-	sort.Strings(categories)
 
-	bestCategory := ""
-	bestNumerator := -1
-	bestDenominator := 1
-	bestCount := -1
-	for _, categoryName := range categories {
-		stat := stats[categoryName]
-		currentNumerator := numerator(stat)
-		if bestCategory == "" || currentNumerator*bestDenominator > bestNumerator*stat.reviewed ||
-			(currentNumerator*bestDenominator == bestNumerator*stat.reviewed && currentNumerator > bestCount) {
-			bestCategory = categoryName
-			bestNumerator = currentNumerator
-			bestDenominator = stat.reviewed
-			bestCount = currentNumerator
+	slices.SortFunc(ranks, func(a, b categoryRank) int {
+		if rateOrder := cmp.Compare(b.rate, a.rate); rateOrder != 0 {
+			return rateOrder
 		}
+		if countOrder := cmp.Compare(b.targetCount, a.targetCount); countOrder != 0 {
+			return countOrder
+		}
+		return cmp.Compare(a.name, b.name)
+	})
+
+	if len(ranks) == 0 {
+		return ""
 	}
-	return bestCategory
+	return ranks[0].name
 }
 
 func busiestWeekday(counts map[time.Weekday]int) (time.Weekday, bool) {
@@ -191,17 +180,4 @@ func busiestWeekday(counts map[time.Weekday]int) (time.Weekday, bool) {
 		}
 	}
 	return top, bestCount > 0
-}
-
-func buildHabitInsight(summary *HabitSummary) string {
-	switch {
-	case summary.ReviewedCount == 0:
-		return "Review a few expenses with /review to build your spending reflection."
-	case summary.MostRegrettedCategory != "":
-		return "Your not-worth-it spending showed up most often in " + summary.MostRegrettedCategory + "."
-	case summary.TopDriver != "":
-		return "Your most common spending driver was " + string(summary.TopDriver) + "."
-	default:
-		return "Keep reviewing expenses to reveal stronger spending patterns."
-	}
 }

--- a/internal/bot/habit_analyzer.go
+++ b/internal/bot/habit_analyzer.go
@@ -1,0 +1,207 @@
+package bot
+
+import (
+	"sort"
+	"time"
+
+	"github.com/shopspring/decimal"
+	appmodels "gitlab.com/yelinaung/expense-bot/internal/models"
+)
+
+type SpendingDriver string
+
+const (
+	minCategoryReflectionSample = 2
+	spendingDriverOther         = SpendingDriver("Other")
+)
+
+// Keep this list append-only and in stable order because callbacks encode indices.
+var spendingDrivers = []SpendingDriver{
+	"Necessity",
+	"Convenience",
+	"Ritual",
+	"Comfort",
+	"Celebration",
+	"Social",
+	"Gift",
+	"Self-care",
+	"Hobby",
+	"Impulse",
+	"Productivity",
+	spendingDriverOther,
+}
+
+type HabitSummary struct {
+	PeriodLabel                     string
+	TotalCount                      int
+	ReviewedCount                   int
+	WorthItCount                    int
+	NotWorthItCount                 int
+	WorthItByCurrency               map[string]decimal.Decimal
+	NotWorthItByCurrency            map[string]decimal.Decimal
+	WorthItByCategoryAndCurrency    map[string]map[string]decimal.Decimal
+	NotWorthItByCategoryAndCurrency map[string]map[string]decimal.Decimal
+	TopDriver                       SpendingDriver
+	BestValueCategory               string
+	MostRegrettedCategory           string
+	BusiestNotWorthItWeekday        time.Weekday
+	HasBusiestNotWorthItWeekday     bool
+	Insight                         string
+}
+
+type categoryReflectionStats struct {
+	reviewed int
+	worth    int
+	notWorth int
+}
+
+func AnalyzeExpenseHabit(
+	allExpenses []appmodels.Expense,
+	reviewedExpenses []appmodels.Expense,
+	loc *time.Location,
+	periodLabel string,
+) HabitSummary {
+	loc = normalizeLocation(loc)
+	summary := HabitSummary{
+		PeriodLabel:                     periodLabel,
+		TotalCount:                      len(allExpenses),
+		WorthItByCurrency:               make(map[string]decimal.Decimal),
+		NotWorthItByCurrency:            make(map[string]decimal.Decimal),
+		WorthItByCategoryAndCurrency:    make(map[string]map[string]decimal.Decimal),
+		NotWorthItByCategoryAndCurrency: make(map[string]map[string]decimal.Decimal),
+	}
+
+	driverCounts := make(map[SpendingDriver]int)
+	categoryStats := make(map[string]categoryReflectionStats)
+	weekdayCounts := make(map[time.Weekday]int)
+
+	for i := range reviewedExpenses {
+		expense := reviewedExpenses[i]
+		if expense.WorthIt == nil {
+			continue
+		}
+
+		summary.ReviewedCount++
+		categoryName := habitCategoryName(&expense)
+		stats := categoryStats[categoryName]
+		stats.reviewed++
+
+		if expense.SpendDriver != nil && *expense.SpendDriver != "" {
+			driverCounts[SpendingDriver(*expense.SpendDriver)]++
+		}
+
+		if *expense.WorthIt {
+			summary.WorthItCount++
+			stats.worth++
+			summary.WorthItByCurrency[expense.Currency] = summary.WorthItByCurrency[expense.Currency].Add(expense.Amount)
+			addCategoryCurrencyTotal(summary.WorthItByCategoryAndCurrency, categoryName, expense.Currency, expense.Amount)
+		} else {
+			summary.NotWorthItCount++
+			stats.notWorth++
+			summary.NotWorthItByCurrency[expense.Currency] = summary.NotWorthItByCurrency[expense.Currency].Add(expense.Amount)
+			addCategoryCurrencyTotal(summary.NotWorthItByCategoryAndCurrency, categoryName, expense.Currency, expense.Amount)
+			weekdayCounts[expense.CreatedAt.In(loc).Weekday()]++
+		}
+
+		categoryStats[categoryName] = stats
+	}
+
+	summary.TopDriver = topSpendingDriver(driverCounts)
+	summary.BestValueCategory = bestValueCategory(categoryStats)
+	summary.MostRegrettedCategory = mostRegrettedCategory(categoryStats)
+	summary.BusiestNotWorthItWeekday, summary.HasBusiestNotWorthItWeekday = busiestWeekday(weekdayCounts)
+	summary.Insight = buildHabitInsight(&summary)
+
+	return summary
+}
+
+func habitCategoryName(expense *appmodels.Expense) string {
+	if expense.Category != nil && expense.Category.Name != "" {
+		return expense.Category.Name
+	}
+	return categoryUncategorized
+}
+
+func addCategoryCurrencyTotal(
+	totals map[string]map[string]decimal.Decimal,
+	categoryName string,
+	currency string,
+	amount decimal.Decimal,
+) {
+	if totals[categoryName] == nil {
+		totals[categoryName] = make(map[string]decimal.Decimal)
+	}
+	totals[categoryName][currency] = totals[categoryName][currency].Add(amount)
+}
+
+func topSpendingDriver(counts map[SpendingDriver]int) SpendingDriver {
+	var top SpendingDriver
+	bestCount := 0
+	for driver, count := range counts {
+		if count > bestCount || (count == bestCount && (top == "" || string(driver) < string(top))) {
+			top = driver
+			bestCount = count
+		}
+	}
+	return top
+}
+
+func bestValueCategory(stats map[string]categoryReflectionStats) string {
+	return rankedCategory(stats, func(s categoryReflectionStats) int { return s.worth })
+}
+
+func mostRegrettedCategory(stats map[string]categoryReflectionStats) string {
+	return rankedCategory(stats, func(s categoryReflectionStats) int { return s.notWorth })
+}
+
+func rankedCategory(stats map[string]categoryReflectionStats, numerator func(categoryReflectionStats) int) string {
+	categories := make([]string, 0, len(stats))
+	for categoryName, stat := range stats {
+		if stat.reviewed >= minCategoryReflectionSample {
+			categories = append(categories, categoryName)
+		}
+	}
+	sort.Strings(categories)
+
+	bestCategory := ""
+	bestNumerator := -1
+	bestDenominator := 1
+	bestCount := -1
+	for _, categoryName := range categories {
+		stat := stats[categoryName]
+		currentNumerator := numerator(stat)
+		if bestCategory == "" || currentNumerator*bestDenominator > bestNumerator*stat.reviewed ||
+			(currentNumerator*bestDenominator == bestNumerator*stat.reviewed && currentNumerator > bestCount) {
+			bestCategory = categoryName
+			bestNumerator = currentNumerator
+			bestDenominator = stat.reviewed
+			bestCount = currentNumerator
+		}
+	}
+	return bestCategory
+}
+
+func busiestWeekday(counts map[time.Weekday]int) (time.Weekday, bool) {
+	var top time.Weekday
+	bestCount := 0
+	for weekday, count := range counts {
+		if count > bestCount || (count == bestCount && weekday < top) {
+			top = weekday
+			bestCount = count
+		}
+	}
+	return top, bestCount > 0
+}
+
+func buildHabitInsight(summary *HabitSummary) string {
+	switch {
+	case summary.ReviewedCount == 0:
+		return "Review a few expenses with /review to build your spending reflection."
+	case summary.MostRegrettedCategory != "":
+		return "Your not-worth-it spending showed up most often in " + summary.MostRegrettedCategory + "."
+	case summary.TopDriver != "":
+		return "Your most common spending driver was " + string(summary.TopDriver) + "."
+	default:
+		return "Keep reviewing expenses to reveal stronger spending patterns."
+	}
+}

--- a/internal/bot/habit_analyzer_test.go
+++ b/internal/bot/habit_analyzer_test.go
@@ -69,7 +69,7 @@ func TestAnalyzeExpenseHabit_MultiCurrencyAndCategoryRules(t *testing.T) {
 	all := append([]appmodels.Expense{}, reviewed...)
 	all = append(all, appmodels.Expense{Amount: decimal.RequireFromString("9.00"), Currency: "SGD"})
 
-	summary := AnalyzeExpenseHabit(all, reviewed, loc, "June 2026")
+	summary := analyzeExpenseHabit(len(all), reviewed, loc, "June 2026")
 
 	require.Equal(t, "June 2026", summary.PeriodLabel)
 	require.Equal(t, 6, summary.TotalCount)
@@ -81,24 +81,21 @@ func TestAnalyzeExpenseHabit_MultiCurrencyAndCategoryRules(t *testing.T) {
 	require.True(t, decimal.RequireFromString("75.00").Equal(summary.NotWorthItByCurrency["SGD"]))
 	require.Equal(t, "Food", summary.BestValueCategory)
 	require.Equal(t, "Travel", summary.MostRegrettedCategory)
-	require.Equal(t, SpendingDriver("Necessity"), summary.TopDriver)
+	require.Equal(t, spendingDriver("Necessity"), summary.TopDriver)
 	require.True(t, summary.HasBusiestNotWorthItWeekday)
 	require.Equal(t, time.Thursday, summary.BusiestNotWorthItWeekday)
-	require.Contains(t, summary.Insight, "Travel")
-	require.Contains(t, summary.NotWorthItByCategoryAndCurrency, categoryUncategorized)
 }
 
 func TestAnalyzeExpenseHabit_NoReviewedExpenses(t *testing.T) {
 	t.Parallel()
 
-	summary := AnalyzeExpenseHabit([]appmodels.Expense{{Currency: "SGD"}}, nil, time.UTC, "This week")
+	summary := analyzeExpenseHabit(1, nil, time.UTC, "This week")
 
 	require.Equal(t, 1, summary.TotalCount)
 	require.Zero(t, summary.ReviewedCount)
 	require.Empty(t, summary.BestValueCategory)
 	require.Empty(t, summary.MostRegrettedCategory)
 	require.False(t, summary.HasBusiestNotWorthItWeekday)
-	require.Contains(t, summary.Insight, "/review")
 }
 
 func TestReviewCallbackDataAndKeyboards(t *testing.T) {
@@ -110,11 +107,11 @@ func TestReviewCallbackDataAndKeyboards(t *testing.T) {
 	require.Equal(t, "Necessity", first.Text)
 	require.LessOrEqual(t, len(first.CallbackData), 64)
 
-	expenseID, worthIt, driverIndex, ok := parseDriverCallback(first.CallbackData)
-	require.True(t, ok)
-	require.Equal(t, 123, expenseID)
-	require.True(t, worthIt)
-	require.Zero(t, driverIndex)
+	callback := parseDriverCallback(first.CallbackData)
+	require.True(t, callback.ok)
+	require.Equal(t, 123, callback.expenseID)
+	require.True(t, callback.worthIt)
+	require.Zero(t, callback.driverIndex)
 
 	reflectionKeyboard := buildExpenseReflectionKeyboard(456)
 	require.Len(t, reflectionKeyboard.InlineKeyboard, 2)
@@ -125,7 +122,7 @@ func TestReviewCallbackDataAndKeyboards(t *testing.T) {
 func TestFormatHabitSummary_PerCurrencyTotals(t *testing.T) {
 	t.Parallel()
 
-	summary := HabitSummary{
+	summary := habitSummary{
 		PeriodLabel:           "Last 90 days",
 		TotalCount:            3,
 		ReviewedCount:         2,
@@ -136,7 +133,6 @@ func TestFormatHabitSummary_PerCurrencyTotals(t *testing.T) {
 		TopDriver:             "Convenience",
 		BestValueCategory:     "Food",
 		MostRegrettedCategory: "Travel",
-		Insight:               "Keep going.",
 	}
 
 	text := formatHabitSummary(&summary)
@@ -145,4 +141,5 @@ func TestFormatHabitSummary_PerCurrencyTotals(t *testing.T) {
 	require.Contains(t, text, "USD: $8.25")
 	require.Contains(t, text, "Best-value category: Food")
 	require.Contains(t, text, "Most-regretted category: Travel")
+	require.Contains(t, text, "not-worth-it spending showed up most often in Travel")
 }

--- a/internal/bot/habit_analyzer_test.go
+++ b/internal/bot/habit_analyzer_test.go
@@ -9,7 +9,7 @@ import (
 	appmodels "gitlab.com/yelinaung/expense-bot/internal/models"
 )
 
-func TestAnalyzeExpenseHabit_MultiCurrencyAndCategoryRules(t *testing.T) {
+func TestAnalyzeExpenseHabit(t *testing.T) {
 	t.Parallel()
 
 	loc := time.FixedZone("SGT", 8*60*60)
@@ -66,36 +66,82 @@ func TestAnalyzeExpenseHabit_MultiCurrencyAndCategoryRules(t *testing.T) {
 			CreatedAt:  time.Date(2026, 6, 12, 10, 0, 0, 0, loc),
 		},
 	}
-	all := append([]appmodels.Expense{}, reviewed...)
-	all = append(all, appmodels.Expense{Amount: decimal.RequireFromString("9.00"), Currency: "SGD"})
 
-	summary := analyzeExpenseHabit(len(all), reviewed, loc, "June 2026")
+	tests := []struct {
+		name                         string
+		totalCount                   int
+		reviewed                     []appmodels.Expense
+		loc                          *time.Location
+		periodLabel                  string
+		wantReviewedCount            int
+		wantWorthItCount             int
+		wantNotWorthItCount          int
+		wantWorthItByCurrency        map[string]string
+		wantNotWorthItByCurrency     map[string]string
+		wantBestValueCategory        string
+		wantMostRegrettedCategory    string
+		wantTopDriver                spendingDriver
+		wantBusiestNotWorthItWeekday time.Weekday
+		wantHasBusiestWeekday        bool
+	}{
+		{
+			name:                         "multi-currency and category rules",
+			totalCount:                   6,
+			reviewed:                     reviewed,
+			loc:                          loc,
+			periodLabel:                  "June 2026",
+			wantReviewedCount:            5,
+			wantWorthItCount:             2,
+			wantNotWorthItCount:          3,
+			wantWorthItByCurrency:        map[string]string{"SGD": "10.00", "USD": "12.00"},
+			wantNotWorthItByCurrency:     map[string]string{"SGD": "75.00"},
+			wantBestValueCategory:        "Food",
+			wantMostRegrettedCategory:    "Travel",
+			wantTopDriver:                spendingDriver("Necessity"),
+			wantBusiestNotWorthItWeekday: time.Thursday,
+			wantHasBusiestWeekday:        true,
+		},
+		{
+			name:                     "no reviewed expenses",
+			totalCount:               1,
+			loc:                      time.UTC,
+			periodLabel:              "This week",
+			wantWorthItByCurrency:    map[string]string{},
+			wantNotWorthItByCurrency: map[string]string{},
+		},
+	}
 
-	require.Equal(t, "June 2026", summary.PeriodLabel)
-	require.Equal(t, 6, summary.TotalCount)
-	require.Equal(t, 5, summary.ReviewedCount)
-	require.Equal(t, 2, summary.WorthItCount)
-	require.Equal(t, 3, summary.NotWorthItCount)
-	require.True(t, decimal.RequireFromString("10.00").Equal(summary.WorthItByCurrency["SGD"]))
-	require.True(t, decimal.RequireFromString("12.00").Equal(summary.WorthItByCurrency["USD"]))
-	require.True(t, decimal.RequireFromString("75.00").Equal(summary.NotWorthItByCurrency["SGD"]))
-	require.Equal(t, "Food", summary.BestValueCategory)
-	require.Equal(t, "Travel", summary.MostRegrettedCategory)
-	require.Equal(t, spendingDriver("Necessity"), summary.TopDriver)
-	require.True(t, summary.HasBusiestNotWorthItWeekday)
-	require.Equal(t, time.Thursday, summary.BusiestNotWorthItWeekday)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			summary := analyzeExpenseHabit(tt.totalCount, tt.reviewed, tt.loc, tt.periodLabel)
+
+			require.Equal(t, tt.periodLabel, summary.PeriodLabel)
+			require.Equal(t, tt.totalCount, summary.TotalCount)
+			require.Equal(t, tt.wantReviewedCount, summary.ReviewedCount)
+			require.Equal(t, tt.wantWorthItCount, summary.WorthItCount)
+			require.Equal(t, tt.wantNotWorthItCount, summary.NotWorthItCount)
+			requireCurrencyTotals(t, tt.wantWorthItByCurrency, summary.WorthItByCurrency)
+			requireCurrencyTotals(t, tt.wantNotWorthItByCurrency, summary.NotWorthItByCurrency)
+			require.Equal(t, tt.wantBestValueCategory, summary.BestValueCategory)
+			require.Equal(t, tt.wantMostRegrettedCategory, summary.MostRegrettedCategory)
+			require.Equal(t, tt.wantTopDriver, summary.TopDriver)
+			require.Equal(t, tt.wantHasBusiestWeekday, summary.HasBusiestNotWorthItWeekday)
+			if tt.wantHasBusiestWeekday {
+				require.Equal(t, tt.wantBusiestNotWorthItWeekday, summary.BusiestNotWorthItWeekday)
+			}
+		})
+	}
 }
 
-func TestAnalyzeExpenseHabit_NoReviewedExpenses(t *testing.T) {
-	t.Parallel()
+func requireCurrencyTotals(t *testing.T, want map[string]string, got map[string]decimal.Decimal) {
+	t.Helper()
 
-	summary := analyzeExpenseHabit(1, nil, time.UTC, "This week")
-
-	require.Equal(t, 1, summary.TotalCount)
-	require.Zero(t, summary.ReviewedCount)
-	require.Empty(t, summary.BestValueCategory)
-	require.Empty(t, summary.MostRegrettedCategory)
-	require.False(t, summary.HasBusiestNotWorthItWeekday)
+	require.Len(t, got, len(want))
+	for currency, amount := range want {
+		require.True(t, decimal.RequireFromString(amount).Equal(got[currency]))
+	}
 }
 
 func TestReviewCallbackDataAndKeyboards(t *testing.T) {

--- a/internal/bot/habit_analyzer_test.go
+++ b/internal/bot/habit_analyzer_test.go
@@ -1,0 +1,148 @@
+package bot
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/require"
+	appmodels "gitlab.com/yelinaung/expense-bot/internal/models"
+)
+
+func TestAnalyzeExpenseHabit_MultiCurrencyAndCategoryRules(t *testing.T) {
+	t.Parallel()
+
+	loc := time.FixedZone("SGT", 8*60*60)
+	food := &appmodels.Category{Name: "Food"}
+	travel := &appmodels.Category{Name: "Travel"}
+	selfCare := "Self-care"
+	necessity := "Necessity"
+	worth := true
+	notWorth := false
+	reviewedAt := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+
+	reviewed := []appmodels.Expense{
+		{
+			Amount:      decimal.RequireFromString("10.00"),
+			Currency:    "SGD",
+			Category:    food,
+			WorthIt:     &worth,
+			SpendDriver: &selfCare,
+			ReviewedAt:  &reviewedAt,
+			CreatedAt:   time.Date(2026, 6, 9, 10, 0, 0, 0, loc),
+		},
+		{
+			Amount:      decimal.RequireFromString("12.00"),
+			Currency:    "USD",
+			Category:    food,
+			WorthIt:     &worth,
+			SpendDriver: &selfCare,
+			ReviewedAt:  &reviewedAt,
+			CreatedAt:   time.Date(2026, 6, 10, 10, 0, 0, 0, loc),
+		},
+		{
+			Amount:      decimal.RequireFromString("30.00"),
+			Currency:    "SGD",
+			Category:    travel,
+			WorthIt:     &notWorth,
+			SpendDriver: &necessity,
+			ReviewedAt:  &reviewedAt,
+			CreatedAt:   time.Date(2026, 6, 11, 10, 0, 0, 0, loc),
+		},
+		{
+			Amount:      decimal.RequireFromString("40.00"),
+			Currency:    "SGD",
+			Category:    travel,
+			WorthIt:     &notWorth,
+			SpendDriver: &necessity,
+			ReviewedAt:  &reviewedAt,
+			CreatedAt:   time.Date(2026, 6, 11, 16, 0, 0, 0, loc),
+		},
+		{
+			Amount:     decimal.RequireFromString("5.00"),
+			Currency:   "SGD",
+			WorthIt:    &notWorth,
+			ReviewedAt: &reviewedAt,
+			CreatedAt:  time.Date(2026, 6, 12, 10, 0, 0, 0, loc),
+		},
+	}
+	all := append([]appmodels.Expense{}, reviewed...)
+	all = append(all, appmodels.Expense{Amount: decimal.RequireFromString("9.00"), Currency: "SGD"})
+
+	summary := AnalyzeExpenseHabit(all, reviewed, loc, "June 2026")
+
+	require.Equal(t, "June 2026", summary.PeriodLabel)
+	require.Equal(t, 6, summary.TotalCount)
+	require.Equal(t, 5, summary.ReviewedCount)
+	require.Equal(t, 2, summary.WorthItCount)
+	require.Equal(t, 3, summary.NotWorthItCount)
+	require.True(t, decimal.RequireFromString("10.00").Equal(summary.WorthItByCurrency["SGD"]))
+	require.True(t, decimal.RequireFromString("12.00").Equal(summary.WorthItByCurrency["USD"]))
+	require.True(t, decimal.RequireFromString("75.00").Equal(summary.NotWorthItByCurrency["SGD"]))
+	require.Equal(t, "Food", summary.BestValueCategory)
+	require.Equal(t, "Travel", summary.MostRegrettedCategory)
+	require.Equal(t, SpendingDriver("Necessity"), summary.TopDriver)
+	require.True(t, summary.HasBusiestNotWorthItWeekday)
+	require.Equal(t, time.Thursday, summary.BusiestNotWorthItWeekday)
+	require.Contains(t, summary.Insight, "Travel")
+	require.Contains(t, summary.NotWorthItByCategoryAndCurrency, categoryUncategorized)
+}
+
+func TestAnalyzeExpenseHabit_NoReviewedExpenses(t *testing.T) {
+	t.Parallel()
+
+	summary := AnalyzeExpenseHabit([]appmodels.Expense{{Currency: "SGD"}}, nil, time.UTC, "This week")
+
+	require.Equal(t, 1, summary.TotalCount)
+	require.Zero(t, summary.ReviewedCount)
+	require.Empty(t, summary.BestValueCategory)
+	require.Empty(t, summary.MostRegrettedCategory)
+	require.False(t, summary.HasBusiestNotWorthItWeekday)
+	require.Contains(t, summary.Insight, "/review")
+}
+
+func TestReviewCallbackDataAndKeyboards(t *testing.T) {
+	t.Parallel()
+
+	driverKeyboard := buildDriverKeyboard(123, true)
+	require.NotEmpty(t, driverKeyboard.InlineKeyboard)
+	first := driverKeyboard.InlineKeyboard[0][0]
+	require.Equal(t, "Necessity", first.Text)
+	require.LessOrEqual(t, len(first.CallbackData), 64)
+
+	expenseID, worthIt, driverIndex, ok := parseDriverCallback(first.CallbackData)
+	require.True(t, ok)
+	require.Equal(t, 123, expenseID)
+	require.True(t, worthIt)
+	require.Zero(t, driverIndex)
+
+	reflectionKeyboard := buildExpenseReflectionKeyboard(456)
+	require.Len(t, reflectionKeyboard.InlineKeyboard, 2)
+	require.Len(t, reflectionKeyboard.InlineKeyboard[1], 3)
+	require.Equal(t, "review_later_456", reflectionKeyboard.InlineKeyboard[1][2].CallbackData)
+}
+
+func TestFormatHabitSummary_PerCurrencyTotals(t *testing.T) {
+	t.Parallel()
+
+	summary := HabitSummary{
+		PeriodLabel:           "Last 90 days",
+		TotalCount:            3,
+		ReviewedCount:         2,
+		WorthItCount:          1,
+		NotWorthItCount:       1,
+		WorthItByCurrency:     map[string]decimal.Decimal{"SGD": decimal.RequireFromString("12.50")},
+		NotWorthItByCurrency:  map[string]decimal.Decimal{"USD": decimal.RequireFromString("8.25")},
+		TopDriver:             "Convenience",
+		BestValueCategory:     "Food",
+		MostRegrettedCategory: "Travel",
+		Insight:               "Keep going.",
+	}
+
+	text := formatHabitSummary(&summary)
+
+	require.Contains(t, text, "SGD: S$12.50")
+	require.Contains(t, text, "USD: $8.25")
+	require.Contains(t, text, "Best-value category: Food")
+	require.Contains(t, text, "Most-regretted category: Travel")
+}

--- a/internal/bot/handlers_callbacks.go
+++ b/internal/bot/handlers_callbacks.go
@@ -17,6 +17,7 @@ const (
 	editCancelText                 = "⬅️ Cancel"
 	cancelEditCallback             = "cancel_edit_%d"
 	expenseNotFoundMsgCB           = "❌ Expense not found."
+	expenseUnexpectedErrorMsgCB    = "❌ Something went wrong while loading this expense. Please try again later."
 	backButtonTextCB               = "⬅️ Back"
 	logFieldExpenseIDCB            = "expense_id"
 	logFieldUserHashCB             = "user_hash"

--- a/internal/bot/handlers_commands.go
+++ b/internal/bot/handlers_commands.go
@@ -120,12 +120,15 @@ func (b *Bot) handleHelpCore(ctx context.Context, tg TelegramAPI, update *models
 • <code>/today</code> - Show today's expenses
 • <code>/week</code> - Show this week's expenses
 • <code>/category &lt;name&gt;</code> - Filter expenses by category
+• <code>/review</code> - Review recent spending as worth it or not worth it
 
 <b>Reports:</b>
 • <code>/report week</code> - Generate weekly CSV report
 • <code>/report month</code> - Generate monthly CSV report
 • <code>/chart week</code> - Generate weekly expense chart
 • <code>/chart month</code> - Generate monthly expense chart
+• <code>/habit</code> - Show this month's spending reflection
+• <code>/habit week</code> or <code>/habit 90d</code> - Change reflection period
 
 <b>Categories:</b>
 • <code>/categories</code> - List all categories
@@ -635,15 +638,7 @@ func (b *Bot) saveExpenseCore(
 
 	text := buildExpenseAddedMessage(expense, parsed.Tags)
 
-	// Add inline edit/delete buttons
-	keyboard := &models.InlineKeyboardMarkup{
-		InlineKeyboard: [][]models.InlineKeyboardButton{
-			{
-				{Text: editExpenseButtonTextCB, CallbackData: fmt.Sprintf(editExpenseCallbackFmtCB, expense.ID)},
-				{Text: deleteExpenseButtonTextCB, CallbackData: fmt.Sprintf(deleteExpenseCallbackFmtCB, expense.ID)},
-			},
-		},
-	}
+	keyboard := buildExpenseReflectionKeyboard(expense.ID)
 
 	if _, err := tg.SendMessage(ctx, &bot.SendMessageParams{
 		ChatID:      chatID,

--- a/internal/bot/handlers_core_test.go
+++ b/internal/bot/handlers_core_test.go
@@ -35,7 +35,8 @@ const (
 )
 
 func makeCategorySuggestionPayload(reason string, matched bool, newCategoryName string) string {
-	return fmt.Sprintf(`{%q:"",%q:0.95,%q:%q,%q:%t,%q:%q}`,
+	return fmt.Sprintf(
+		`{%q:"",%q:0.95,%q:%q,%q:%t,%q:%q}`,
 		botRespCategoryKeyCoreTest,
 		botRespConfidenceKeyCoreTest,
 		botRespReasoningKeyCoreTest,

--- a/internal/bot/handlers_habit.go
+++ b/internal/bot/handlers_habit.go
@@ -116,7 +116,7 @@ func (b *Bot) handleReviewCallback(ctx context.Context, tgBot *bot.Bot, update *
 }
 
 func (b *Bot) handleReviewCallbackCore(ctx context.Context, tg TelegramAPI, update *models.Update) {
-	if update.CallbackQuery == nil || update.CallbackQuery.Message.Message == nil {
+	if update.CallbackQuery == nil || update.CallbackQuery.Message == nil || update.CallbackQuery.Message.Message == nil {
 		return
 	}
 

--- a/internal/bot/handlers_habit.go
+++ b/internal/bot/handlers_habit.go
@@ -406,7 +406,7 @@ func formatReviewPrompt(expense *appmodels.Expense, loc *time.Location) string {
 %s
 %s
 %s`,
-		escapeHTML(currencySymbol(expense.Currency)),
+		escapeHTML(getCurrencyOrCodeSymbol(expense.Currency)),
 		escapeHTML(expense.Amount.StringFixed(2)),
 		escapeHTML(expense.Currency),
 		escapeHTML(description),

--- a/internal/bot/handlers_habit.go
+++ b/internal/bot/handlers_habit.go
@@ -116,7 +116,7 @@ func (b *Bot) handleReviewCallback(ctx context.Context, tgBot *bot.Bot, update *
 }
 
 func (b *Bot) handleReviewCallbackCore(ctx context.Context, tg TelegramAPI, update *models.Update) {
-	if update.CallbackQuery == nil || update.CallbackQuery.Message == nil || update.CallbackQuery.Message.Message == nil {
+	if update.CallbackQuery == nil || update.CallbackQuery.Message.Message == nil {
 		return
 	}
 

--- a/internal/bot/handlers_habit.go
+++ b/internal/bot/handlers_habit.go
@@ -1,0 +1,475 @@
+package bot
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-telegram/bot"
+	"github.com/go-telegram/bot/models"
+	"github.com/jackc/pgx/v5"
+	"github.com/shopspring/decimal"
+	"gitlab.com/yelinaung/expense-bot/internal/logger"
+	appmodels "gitlab.com/yelinaung/expense-bot/internal/models"
+)
+
+const (
+	reviewWorthPrefix    = "review_worth_"
+	reviewNotWorthPrefix = "review_not_worth_"
+	reviewLaterPrefix    = "review_later_"
+	reviewSkipPrefix     = "review_skip_"
+	reviewDriverPrefix   = "review_driver_"
+)
+
+func (b *Bot) handleReview(ctx context.Context, tgBot *bot.Bot, update *models.Update) {
+	b.handleReviewCore(ctx, tgBot, update)
+}
+
+func (b *Bot) handleReviewCore(ctx context.Context, tg TelegramAPI, update *models.Update) {
+	if update.Message == nil || update.Message.From == nil {
+		return
+	}
+
+	chatID := update.Message.Chat.ID
+	userID := update.Message.From.ID
+	expenses, err := b.expenseRepo.GetUnreviewedByUserID(ctx, userID, 1)
+	if err != nil {
+		logger.Log.Error().Err(err).Msg("Failed to fetch unreviewed expenses")
+		_, _ = tg.SendMessage(ctx, &bot.SendMessageParams{ChatID: chatID, Text: failedFetchExpensesMsg})
+		return
+	}
+	if len(expenses) == 0 {
+		_, _ = tg.SendMessage(ctx, &bot.SendMessageParams{ChatID: chatID, Text: "No expenses to review."})
+		return
+	}
+
+	loc := b.locationForUser(ctx, userID)
+	_, _ = tg.SendMessage(ctx, &bot.SendMessageParams{
+		ChatID:      chatID,
+		Text:        formatReviewPrompt(&expenses[0], loc),
+		ParseMode:   models.ParseModeHTML,
+		ReplyMarkup: buildReviewKeyboard(expenses[0].ID),
+	})
+}
+
+func (b *Bot) handleHabit(ctx context.Context, tgBot *bot.Bot, update *models.Update) {
+	b.handleHabitCore(ctx, tgBot, update)
+}
+
+func (b *Bot) handleHabitCore(ctx context.Context, tg TelegramAPI, update *models.Update) {
+	if update.Message == nil || update.Message.From == nil {
+		return
+	}
+
+	chatID := update.Message.Chat.ID
+	userID := update.Message.From.ID
+	period := strings.ToLower(extractCommandArgs(update.Message.Text, "/habit"))
+	if period == "" {
+		period = periodMonth
+	}
+
+	loc := b.locationForUser(ctx, userID)
+	current := b.now().In(loc)
+	startDate, endDate, label, ok := habitPeriodRange(period, current)
+	if !ok {
+		_, _ = tg.SendMessage(ctx, &bot.SendMessageParams{
+			ChatID:    chatID,
+			Text:      "Invalid habit period. Use <code>/habit week</code>, <code>/habit month</code>, or <code>/habit 90d</code>.",
+			ParseMode: models.ParseModeHTML,
+		})
+		return
+	}
+
+	expenses, err := b.expenseRepo.GetByUserIDAndDateRange(ctx, userID, startDate, endDate)
+	if err != nil {
+		logger.Log.Error().Err(err).Msg("Failed to fetch expenses for habit summary")
+		_, _ = tg.SendMessage(ctx, &bot.SendMessageParams{ChatID: chatID, Text: failedFetchExpensesMsg})
+		return
+	}
+
+	reviewed, err := b.expenseRepo.GetReviewedByUserIDAndDateRange(ctx, userID, startDate, endDate)
+	if err != nil {
+		logger.Log.Error().Err(err).Msg("Failed to fetch reviewed expenses for habit summary")
+		_, _ = tg.SendMessage(ctx, &bot.SendMessageParams{ChatID: chatID, Text: failedFetchExpensesMsg})
+		return
+	}
+
+	summary := AnalyzeExpenseHabit(expenses, reviewed, loc, label)
+	_, _ = tg.SendMessage(ctx, &bot.SendMessageParams{
+		ChatID:    chatID,
+		Text:      formatHabitSummary(&summary),
+		ParseMode: models.ParseModeHTML,
+	})
+}
+
+func (b *Bot) handleReviewCallback(ctx context.Context, tgBot *bot.Bot, update *models.Update) {
+	b.handleReviewCallbackCore(ctx, tgBot, update)
+}
+
+func (b *Bot) handleReviewCallbackCore(ctx context.Context, tg TelegramAPI, update *models.Update) {
+	if update.CallbackQuery == nil || update.CallbackQuery.Message.Message == nil {
+		return
+	}
+
+	data := update.CallbackQuery.Data
+	userID := update.CallbackQuery.From.ID
+	chatID := update.CallbackQuery.Message.Message.Chat.ID
+	messageID := update.CallbackQuery.Message.Message.ID
+
+	_, _ = tg.AnswerCallbackQuery(ctx, &bot.AnswerCallbackQueryParams{CallbackQueryID: update.CallbackQuery.ID})
+
+	switch {
+	case strings.HasPrefix(data, reviewWorthPrefix):
+		expenseID, ok := parseReviewID(data, reviewWorthPrefix)
+		if ok {
+			b.showDriverPrompt(ctx, tg, chatID, messageID, userID, expenseID, true)
+		}
+	case strings.HasPrefix(data, reviewNotWorthPrefix):
+		expenseID, ok := parseReviewID(data, reviewNotWorthPrefix)
+		if ok {
+			b.showDriverPrompt(ctx, tg, chatID, messageID, userID, expenseID, false)
+		}
+	case strings.HasPrefix(data, reviewLaterPrefix):
+		expenseID, ok := parseReviewID(data, reviewLaterPrefix)
+		if ok {
+			b.dismissReflectionButtons(ctx, tg, chatID, messageID, userID, expenseID)
+		}
+	case strings.HasPrefix(data, reviewSkipPrefix):
+		expenseID, ok := parseReviewID(data, reviewSkipPrefix)
+		if ok {
+			b.editToNextReviewOrDone(ctx, tg, chatID, messageID, userID, expenseID)
+		}
+	case strings.HasPrefix(data, reviewDriverPrefix):
+		b.handleReviewDriverCallback(ctx, tg, chatID, messageID, userID, data)
+	}
+}
+
+func (b *Bot) showDriverPrompt(
+	ctx context.Context,
+	tg TelegramAPI,
+	chatID int64,
+	messageID int,
+	userID int64,
+	expenseID int,
+	worthIt bool,
+) {
+	expense, ok := b.getOwnedExpense(ctx, tg, updateTarget{chatID: chatID, messageID: messageID}, userID, expenseID)
+	if !ok {
+		return
+	}
+
+	loc := b.locationForUser(ctx, userID)
+	text := formatReviewPrompt(expense, loc) + "\n\n<b>What drove this spend?</b>"
+	_, _ = tg.EditMessageText(ctx, &bot.EditMessageTextParams{
+		ChatID:      chatID,
+		MessageID:   messageID,
+		Text:        text,
+		ParseMode:   models.ParseModeHTML,
+		ReplyMarkup: buildDriverKeyboard(expenseID, worthIt),
+	})
+}
+
+func (b *Bot) handleReviewDriverCallback(
+	ctx context.Context,
+	tg TelegramAPI,
+	chatID int64,
+	messageID int,
+	userID int64,
+	data string,
+) {
+	expenseID, worthIt, driverIndex, ok := parseDriverCallback(data)
+	if !ok || driverIndex < 0 || driverIndex >= len(spendingDrivers) {
+		return
+	}
+	if _, ok := b.getOwnedExpense(ctx, tg, updateTarget{chatID: chatID, messageID: messageID}, userID, expenseID); !ok {
+		return
+	}
+
+	worth := worthIt
+	driver := string(spendingDrivers[driverIndex])
+	if err := b.expenseRepo.UpdateReflection(ctx, expenseID, userID, &worth, driver); err != nil {
+		logger.Log.Error().Err(err).Int("expense_id", expenseID).Msg("Failed to update reflection")
+		_, _ = tg.EditMessageText(ctx, &bot.EditMessageTextParams{
+			ChatID:    chatID,
+			MessageID: messageID,
+			Text:      "Failed to save reflection. Please try again.",
+		})
+		return
+	}
+
+	b.editToNextReviewOrDone(ctx, tg, chatID, messageID, userID, expenseID)
+}
+
+type updateTarget struct {
+	chatID    int64
+	messageID int
+}
+
+func (b *Bot) getOwnedExpense(
+	ctx context.Context,
+	tg TelegramAPI,
+	target updateTarget,
+	userID int64,
+	expenseID int,
+) (*appmodels.Expense, bool) {
+	expense, err := b.expenseRepo.GetByID(ctx, expenseID)
+	if err != nil || expense.UserID != userID {
+		_, _ = tg.EditMessageText(ctx, &bot.EditMessageTextParams{
+			ChatID:    target.chatID,
+			MessageID: target.messageID,
+			Text:      expenseNotFoundMsgCB,
+		})
+		return nil, false
+	}
+	return expense, true
+}
+
+func (b *Bot) dismissReflectionButtons(
+	ctx context.Context,
+	tg TelegramAPI,
+	chatID int64,
+	messageID int,
+	userID int64,
+	expenseID int,
+) {
+	expense, ok := b.getOwnedExpense(ctx, tg, updateTarget{chatID: chatID, messageID: messageID}, userID, expenseID)
+	if !ok {
+		return
+	}
+	_, _ = tg.EditMessageText(ctx, &bot.EditMessageTextParams{
+		ChatID:      chatID,
+		MessageID:   messageID,
+		Text:        buildExpenseAddedMessage(expense, nil),
+		ParseMode:   models.ParseModeHTML,
+		ReplyMarkup: buildExpenseActionKeyboard(expense.ID),
+	})
+}
+
+func (b *Bot) editToNextReviewOrDone(
+	ctx context.Context,
+	tg TelegramAPI,
+	chatID int64,
+	messageID int,
+	userID int64,
+	currentExpenseID int,
+) {
+	next, err := b.expenseRepo.GetNextUnreviewedByUserID(ctx, userID, currentExpenseID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			_, _ = tg.EditMessageText(ctx, &bot.EditMessageTextParams{
+				ChatID:    chatID,
+				MessageID: messageID,
+				Text:      "No more expenses to review.",
+			})
+			return
+		}
+		logger.Log.Error().Err(err).Msg("Failed to fetch next unreviewed expense")
+		_, _ = tg.EditMessageText(ctx, &bot.EditMessageTextParams{
+			ChatID:    chatID,
+			MessageID: messageID,
+			Text:      failedFetchExpensesMsg,
+		})
+		return
+	}
+
+	loc := b.locationForUser(ctx, userID)
+	_, _ = tg.EditMessageText(ctx, &bot.EditMessageTextParams{
+		ChatID:      chatID,
+		MessageID:   messageID,
+		Text:        formatReviewPrompt(next, loc),
+		ParseMode:   models.ParseModeHTML,
+		ReplyMarkup: buildReviewKeyboard(next.ID),
+	})
+}
+
+func buildExpenseActionKeyboard(expenseID int) *models.InlineKeyboardMarkup {
+	return &models.InlineKeyboardMarkup{
+		InlineKeyboard: [][]models.InlineKeyboardButton{
+			{
+				{Text: editExpenseButtonTextCB, CallbackData: fmt.Sprintf(editExpenseCallbackFmtCB, expenseID)},
+				{Text: deleteExpenseButtonTextCB, CallbackData: fmt.Sprintf(deleteExpenseCallbackFmtCB, expenseID)},
+			},
+		},
+	}
+}
+
+func buildExpenseReflectionKeyboard(expenseID int) *models.InlineKeyboardMarkup {
+	keyboard := buildExpenseActionKeyboard(expenseID)
+	keyboard.InlineKeyboard = append(keyboard.InlineKeyboard, []models.InlineKeyboardButton{
+		{Text: "Worth it", CallbackData: fmt.Sprintf("%s%d", reviewWorthPrefix, expenseID)},
+		{Text: "Not worth it", CallbackData: fmt.Sprintf("%s%d", reviewNotWorthPrefix, expenseID)},
+		{Text: "Later", CallbackData: fmt.Sprintf("%s%d", reviewLaterPrefix, expenseID)},
+	})
+	return keyboard
+}
+
+func buildReviewKeyboard(expenseID int) *models.InlineKeyboardMarkup {
+	return &models.InlineKeyboardMarkup{
+		InlineKeyboard: [][]models.InlineKeyboardButton{
+			{
+				{Text: "Worth it", CallbackData: fmt.Sprintf("%s%d", reviewWorthPrefix, expenseID)},
+				{Text: "Not worth it", CallbackData: fmt.Sprintf("%s%d", reviewNotWorthPrefix, expenseID)},
+			},
+			{
+				{Text: "Skip", CallbackData: fmt.Sprintf("%s%d", reviewSkipPrefix, expenseID)},
+			},
+		},
+	}
+}
+
+func buildDriverKeyboard(expenseID int, worthIt bool) *models.InlineKeyboardMarkup {
+	worthBit := 0
+	if worthIt {
+		worthBit = 1
+	}
+
+	rows := make([][]models.InlineKeyboardButton, 0, len(spendingDrivers)/2+1)
+	for i := 0; i < len(spendingDrivers); i += 2 {
+		row := []models.InlineKeyboardButton{{
+			Text:         string(spendingDrivers[i]),
+			CallbackData: fmt.Sprintf("%s%d_%d_%d", reviewDriverPrefix, expenseID, worthBit, i),
+		}}
+		if i+1 < len(spendingDrivers) {
+			row = append(row, models.InlineKeyboardButton{
+				Text:         string(spendingDrivers[i+1]),
+				CallbackData: fmt.Sprintf("%s%d_%d_%d", reviewDriverPrefix, expenseID, worthBit, i+1),
+			})
+		}
+		rows = append(rows, row)
+	}
+
+	return &models.InlineKeyboardMarkup{InlineKeyboard: rows}
+}
+
+func parseReviewID(data, prefix string) (int, bool) {
+	expenseID, err := strconv.Atoi(strings.TrimPrefix(data, prefix))
+	return expenseID, err == nil
+}
+
+func parseDriverCallback(data string) (int, bool, int, bool) {
+	payload := strings.TrimPrefix(data, reviewDriverPrefix)
+	parts := strings.Split(payload, "_")
+	if len(parts) != 3 {
+		return 0, false, 0, false
+	}
+	expenseID, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, false, 0, false
+	}
+	worthBit, err := strconv.Atoi(parts[1])
+	if err != nil || (worthBit != 0 && worthBit != 1) {
+		return 0, false, 0, false
+	}
+	driverIndex, err := strconv.Atoi(parts[2])
+	if err != nil {
+		return 0, false, 0, false
+	}
+	return expenseID, worthBit == 1, driverIndex, true
+}
+
+func formatReviewPrompt(expense *appmodels.Expense, loc *time.Location) string {
+	categoryText := categoryUncategorized
+	if expense.Category != nil {
+		categoryText = escapeHTML(expense.Category.Name)
+	}
+	description := expense.Description
+	if description == "" {
+		description = expense.Merchant
+	}
+
+	return fmt.Sprintf(
+		`Spending reflection
+
+<b>Was this worth it?</b>
+
+%s%s %s
+%s
+%s
+%s`,
+		escapeHTML(currencySymbol(expense.Currency)),
+		escapeHTML(expense.Amount.StringFixed(2)),
+		escapeHTML(expense.Currency),
+		escapeHTML(description),
+		escapeHTML(categoryText),
+		escapeHTML(expense.CreatedAt.In(normalizeLocation(loc)).Format("02 Jan 2006 15:04")),
+	)
+}
+
+func habitPeriodRange(period string, current time.Time) (time.Time, time.Time, string, bool) {
+	switch period {
+	case periodWeek:
+		start, end := getWeekDateRangeAt(current)
+		return start, end, "This week", true
+	case periodMonth:
+		start, end := getMonthDateRangeAt(current)
+		return start, end, start.Format("January 2006"), true
+	case "90d":
+		start, end := getRollingDayRangeAt(current, 90)
+		return start, end, "Last 90 days", true
+	default:
+		return time.Time{}, time.Time{}, "", false
+	}
+}
+
+func formatHabitSummary(summary *HabitSummary) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "<b>Spending Reflection</b>\n%s\n\n", escapeHTML(summary.PeriodLabel))
+	fmt.Fprintf(&sb, "Reviewed: %d/%d\n", summary.ReviewedCount, summary.TotalCount)
+	fmt.Fprintf(&sb, "Worth it: %d\n", summary.WorthItCount)
+	fmt.Fprintf(&sb, "Not worth it: %d\n\n", summary.NotWorthItCount)
+
+	sb.WriteString("Worth-it spend:\n")
+	appendCurrencyTotals(&sb, summary.WorthItByCurrency)
+	sb.WriteString("\nNot-worth-it spend:\n")
+	appendCurrencyTotals(&sb, summary.NotWorthItByCurrency)
+
+	fmt.Fprintf(&sb, "\nBest-value category: %s\n", habitCategoryOrFallback(summary.BestValueCategory))
+	fmt.Fprintf(&sb, "Most-regretted category: %s\n", habitCategoryOrFallback(summary.MostRegrettedCategory))
+	if summary.TopDriver != "" {
+		fmt.Fprintf(&sb, "Top driver: %s\n", escapeHTML(string(summary.TopDriver)))
+	} else {
+		sb.WriteString("Top driver: Not enough data\n")
+	}
+	if summary.HasBusiestNotWorthItWeekday {
+		fmt.Fprintf(&sb, "Not-worth-it weekday: %s\n", summary.BusiestNotWorthItWeekday.String())
+	} else {
+		sb.WriteString("Not-worth-it weekday: Not enough data\n")
+	}
+
+	fmt.Fprintf(&sb, "\n%s", escapeHTML(summary.Insight))
+	return sb.String()
+}
+
+func appendCurrencyTotals(sb *strings.Builder, totals map[string]decimal.Decimal) {
+	if len(totals) == 0 {
+		sb.WriteString("  None\n")
+		return
+	}
+	for _, currency := range sortedCurrencyKeys(totals) {
+		fmt.Fprintf(
+			sb, "  %s: %s%s\n",
+			escapeHTML(currency),
+			escapeHTML(currencySymbol(currency)),
+			totals[currency].StringFixed(2),
+		)
+	}
+}
+
+func habitCategoryOrFallback(category string) string {
+	if category == "" {
+		return "Not enough data"
+	}
+	return escapeHTML(category)
+}
+
+func (b *Bot) locationForUser(ctx context.Context, userID int64) *time.Location {
+	user, err := b.userRepo.GetUserByID(ctx, userID)
+	if err != nil {
+		logger.Log.Warn().Err(err).Msg("Failed to fetch user timezone, using fallback location")
+		return b.userLocation("")
+	}
+	return b.userLocation(user.Timezone)
+}

--- a/internal/bot/handlers_habit.go
+++ b/internal/bot/handlers_habit.go
@@ -221,7 +221,30 @@ func (b *Bot) getOwnedExpense(
 	expenseID int,
 ) (*appmodels.Expense, bool) {
 	expense, err := b.expenseRepo.GetByID(ctx, expenseID)
-	if err != nil || expense.UserID != userID {
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			_, _ = tg.EditMessageText(ctx, &bot.EditMessageTextParams{
+				ChatID:    target.chatID,
+				MessageID: target.messageID,
+				Text:      expenseNotFoundMsgCB,
+			})
+			return nil, false
+		}
+
+		logger.Log.Error().
+			Err(err).
+			Int(logFieldExpenseIDCB, expenseID).
+			Str(logFieldUserHashCB, logger.HashUserID(userID)).
+			Msg("Failed to get expense for reflection")
+		_, _ = tg.EditMessageText(ctx, &bot.EditMessageTextParams{
+			ChatID:    target.chatID,
+			MessageID: target.messageID,
+			Text:      expenseUnexpectedErrorMsgCB,
+		})
+		return nil, false
+	}
+
+	if expense.UserID != userID {
 		_, _ = tg.EditMessageText(ctx, &bot.EditMessageTextParams{
 			ChatID:    target.chatID,
 			MessageID: target.messageID,
@@ -410,7 +433,7 @@ func formatReviewPrompt(expense *appmodels.Expense, loc *time.Location) string {
 		escapeHTML(expense.Amount.StringFixed(2)),
 		escapeHTML(expense.Currency),
 		escapeHTML(description),
-		escapeHTML(categoryText),
+		categoryText,
 		escapeHTML(expense.CreatedAt.In(normalizeLocation(loc)).Format("02 Jan 2006 15:04")),
 	)
 }

--- a/internal/bot/handlers_habit.go
+++ b/internal/bot/handlers_habit.go
@@ -482,7 +482,7 @@ func appendCurrencyTotals(sb *strings.Builder, totals map[string]decimal.Decimal
 		fmt.Fprintf(
 			sb, "  %s: %s%s\n",
 			escapeHTML(currency),
-			escapeHTML(currencySymbol(currency)),
+			escapeHTML(getCurrencyOrCodeSymbol(currency)),
 			totals[currency].StringFixed(2),
 		)
 	}

--- a/internal/bot/handlers_habit.go
+++ b/internal/bot/handlers_habit.go
@@ -22,6 +22,12 @@ const (
 	reviewLaterPrefix    = "review_later_"
 	reviewSkipPrefix     = "review_skip_"
 	reviewDriverPrefix   = "review_driver_"
+
+	noExpensesToReviewMsg   = "No expenses to review."
+	noMoreExpensesReviewMsg = "No more expenses to review."
+	driverPromptHTML        = "<b>What drove this spend?</b>"
+	failedSaveReflectionMsg = "Failed to save reflection. Please try again."
+	invalidHabitPeriodMsg   = "Invalid habit period. Use <code>/habit week</code>, <code>/habit month</code>, or <code>/habit 90d</code>."
 )
 
 func (b *Bot) handleReview(ctx context.Context, tgBot *bot.Bot, update *models.Update) {
@@ -42,7 +48,7 @@ func (b *Bot) handleReviewCore(ctx context.Context, tg TelegramAPI, update *mode
 		return
 	}
 	if len(expenses) == 0 {
-		_, _ = tg.SendMessage(ctx, &bot.SendMessageParams{ChatID: chatID, Text: "No expenses to review."})
+		_, _ = tg.SendMessage(ctx, &bot.SendMessageParams{ChatID: chatID, Text: noExpensesToReviewMsg})
 		return
 	}
 
@@ -77,7 +83,7 @@ func (b *Bot) handleHabitCore(ctx context.Context, tg TelegramAPI, update *model
 	if !ok {
 		_, _ = tg.SendMessage(ctx, &bot.SendMessageParams{
 			ChatID:    chatID,
-			Text:      "Invalid habit period. Use <code>/habit week</code>, <code>/habit month</code>, or <code>/habit 90d</code>.",
+			Text:      invalidHabitPeriodMsg,
 			ParseMode: models.ParseModeHTML,
 		})
 		return
@@ -97,7 +103,7 @@ func (b *Bot) handleHabitCore(ctx context.Context, tg TelegramAPI, update *model
 		return
 	}
 
-	summary := AnalyzeExpenseHabit(expenses, reviewed, loc, label)
+	summary := analyzeExpenseHabit(len(expenses), reviewed, loc, label)
 	_, _ = tg.SendMessage(ctx, &bot.SendMessageParams{
 		ChatID:    chatID,
 		Text:      formatHabitSummary(&summary),
@@ -162,7 +168,7 @@ func (b *Bot) showDriverPrompt(
 	}
 
 	loc := b.locationForUser(ctx, userID)
-	text := formatReviewPrompt(expense, loc) + "\n\n<b>What drove this spend?</b>"
+	text := formatReviewPrompt(expense, loc) + "\n\n" + driverPromptHTML
 	_, _ = tg.EditMessageText(ctx, &bot.EditMessageTextParams{
 		ChatID:      chatID,
 		MessageID:   messageID,
@@ -180,27 +186,26 @@ func (b *Bot) handleReviewDriverCallback(
 	userID int64,
 	data string,
 ) {
-	expenseID, worthIt, driverIndex, ok := parseDriverCallback(data)
-	if !ok || driverIndex < 0 || driverIndex >= len(spendingDrivers) {
+	callback := parseDriverCallback(data)
+	if !callback.ok || callback.driverIndex < 0 || callback.driverIndex >= len(spendingDrivers) {
 		return
 	}
-	if _, ok := b.getOwnedExpense(ctx, tg, updateTarget{chatID: chatID, messageID: messageID}, userID, expenseID); !ok {
+	if _, ok := b.getOwnedExpense(ctx, tg, updateTarget{chatID: chatID, messageID: messageID}, userID, callback.expenseID); !ok {
 		return
 	}
 
-	worth := worthIt
-	driver := string(spendingDrivers[driverIndex])
-	if err := b.expenseRepo.UpdateReflection(ctx, expenseID, userID, &worth, driver); err != nil {
-		logger.Log.Error().Err(err).Int("expense_id", expenseID).Msg("Failed to update reflection")
+	driver := string(spendingDrivers[callback.driverIndex])
+	if err := b.expenseRepo.UpdateReflection(ctx, callback.expenseID, userID, &callback.worthIt, driver); err != nil {
+		logger.Log.Error().Err(err).Int("expense_id", callback.expenseID).Msg("Failed to update reflection")
 		_, _ = tg.EditMessageText(ctx, &bot.EditMessageTextParams{
 			ChatID:    chatID,
 			MessageID: messageID,
-			Text:      "Failed to save reflection. Please try again.",
+			Text:      failedSaveReflectionMsg,
 		})
 		return
 	}
 
-	b.editToNextReviewOrDone(ctx, tg, chatID, messageID, userID, expenseID)
+	b.editToNextReviewOrDone(ctx, tg, chatID, messageID, userID, callback.expenseID)
 }
 
 type updateTarget struct {
@@ -262,7 +267,7 @@ func (b *Bot) editToNextReviewOrDone(
 			_, _ = tg.EditMessageText(ctx, &bot.EditMessageTextParams{
 				ChatID:    chatID,
 				MessageID: messageID,
-				Text:      "No more expenses to review.",
+				Text:      noMoreExpensesReviewMsg,
 			})
 			return
 		}
@@ -349,25 +354,37 @@ func parseReviewID(data, prefix string) (int, bool) {
 	return expenseID, err == nil
 }
 
-func parseDriverCallback(data string) (int, bool, int, bool) {
+type reviewDriverCallback struct {
+	expenseID   int
+	worthIt     bool
+	driverIndex int
+	ok          bool
+}
+
+func parseDriverCallback(data string) reviewDriverCallback {
 	payload := strings.TrimPrefix(data, reviewDriverPrefix)
 	parts := strings.Split(payload, "_")
 	if len(parts) != 3 {
-		return 0, false, 0, false
+		return reviewDriverCallback{}
 	}
 	expenseID, err := strconv.Atoi(parts[0])
 	if err != nil {
-		return 0, false, 0, false
+		return reviewDriverCallback{}
 	}
 	worthBit, err := strconv.Atoi(parts[1])
 	if err != nil || (worthBit != 0 && worthBit != 1) {
-		return 0, false, 0, false
+		return reviewDriverCallback{}
 	}
 	driverIndex, err := strconv.Atoi(parts[2])
 	if err != nil {
-		return 0, false, 0, false
+		return reviewDriverCallback{}
 	}
-	return expenseID, worthBit == 1, driverIndex, true
+	return reviewDriverCallback{
+		expenseID:   expenseID,
+		worthIt:     worthBit == 1,
+		driverIndex: driverIndex,
+		ok:          true,
+	}
 }
 
 func formatReviewPrompt(expense *appmodels.Expense, loc *time.Location) string {
@@ -414,7 +431,7 @@ func habitPeriodRange(period string, current time.Time) (time.Time, time.Time, s
 	}
 }
 
-func formatHabitSummary(summary *HabitSummary) string {
+func formatHabitSummary(summary *habitSummary) string {
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "<b>Spending Reflection</b>\n%s\n\n", escapeHTML(summary.PeriodLabel))
 	fmt.Fprintf(&sb, "Reviewed: %d/%d\n", summary.ReviewedCount, summary.TotalCount)
@@ -439,8 +456,21 @@ func formatHabitSummary(summary *HabitSummary) string {
 		sb.WriteString("Not-worth-it weekday: Not enough data\n")
 	}
 
-	fmt.Fprintf(&sb, "\n%s", escapeHTML(summary.Insight))
+	fmt.Fprintf(&sb, "\n%s", escapeHTML(formatHabitInsight(summary)))
 	return sb.String()
+}
+
+func formatHabitInsight(summary *habitSummary) string {
+	switch {
+	case summary.ReviewedCount == 0:
+		return "Review a few expenses with /review to build your spending reflection."
+	case summary.MostRegrettedCategory != "":
+		return "Your not-worth-it spending showed up most often in " + summary.MostRegrettedCategory + "."
+	case summary.TopDriver != "":
+		return "Your most common spending driver was " + string(summary.TopDriver) + "."
+	default:
+		return "Keep reviewing expenses to reveal stronger spending patterns."
+	}
 }
 
 func appendCurrencyTotals(sb *strings.Builder, totals map[string]decimal.Decimal) {

--- a/internal/bot/handlers_habit.go
+++ b/internal/bot/handlers_habit.go
@@ -141,7 +141,7 @@ func (b *Bot) handleReviewCallbackCore(ctx context.Context, tg TelegramAPI, upda
 	case strings.HasPrefix(data, reviewLaterPrefix):
 		expenseID, ok := parseReviewID(data, reviewLaterPrefix)
 		if ok {
-			b.dismissReflectionButtons(ctx, tg, chatID, messageID, userID, expenseID)
+			b.dismissReflectionButtons(ctx, tg, chatID, messageID, userID, expenseID, update.CallbackQuery.Message.Message.Text)
 		}
 	case strings.HasPrefix(data, reviewSkipPrefix):
 		expenseID, ok := parseReviewID(data, reviewSkipPrefix)
@@ -262,15 +262,19 @@ func (b *Bot) dismissReflectionButtons(
 	messageID int,
 	userID int64,
 	expenseID int,
+	text string,
 ) {
 	expense, ok := b.getOwnedExpense(ctx, tg, updateTarget{chatID: chatID, messageID: messageID}, userID, expenseID)
 	if !ok {
 		return
 	}
+	if text == "" {
+		text = buildExpenseAddedMessage(expense, nil)
+	}
 	_, _ = tg.EditMessageText(ctx, &bot.EditMessageTextParams{
 		ChatID:      chatID,
 		MessageID:   messageID,
-		Text:        buildExpenseAddedMessage(expense, nil),
+		Text:        text,
 		ParseMode:   models.ParseModeHTML,
 		ReplyMarkup: buildExpenseActionKeyboard(expense.ID),
 	})

--- a/internal/bot/handlers_habit_core_test.go
+++ b/internal/bot/handlers_habit_core_test.go
@@ -1,0 +1,123 @@
+package bot
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	tgmodels "github.com/go-telegram/bot/models"
+	"github.com/stretchr/testify/require"
+	"gitlab.com/yelinaung/expense-bot/internal/bot/mocks"
+)
+
+// TestHandleHabitReflectionExtraCoverage exercises branches not covered by
+// TestHandleReviewCore / TestHandleReviewCallbackCore / TestHandleHabitCore:
+// the "Later" dismissal, ownership rejection, malformed driver payloads, the
+// week/90d period branches, and the nil-update early returns.
+func TestHandleHabitReflectionExtraCoverage(t *testing.T) {
+	ctx := context.Background()
+	pool := testDB(ctx, t)
+	b := setupTestBot(t, pool)
+	b.nowFunc = func() time.Time {
+		return time.Date(2026, 6, 16, 12, 0, 0, 0, time.UTC)
+	}
+
+	createdAt := time.Date(2026, 6, 16, 10, 0, 0, 0, time.UTC)
+
+	t.Run("habit nil message returns early", func(t *testing.T) {
+		mockBot := mocks.NewMockBot()
+		b.handleHabitCore(ctx, mockBot, &tgmodels.Update{})
+		require.Equal(t, 0, mockBot.SentMessageCount())
+	})
+
+	t.Run("review callback nil callback returns early", func(t *testing.T) {
+		mockBot := mocks.NewMockBot()
+		b.handleReviewCallbackCore(ctx, mockBot, &tgmodels.Update{})
+		require.Equal(t, 0, mockBot.AnsweredCallbackCount())
+		require.Equal(t, 0, mockBot.EditedMessageCount())
+	})
+
+	t.Run("later dismisses reflection buttons without reviewing", func(t *testing.T) {
+		mockBot := mocks.NewMockBot()
+		userID := int64(73401)
+		upsertHabitTestUser(t, ctx, b, userID)
+		expense := createHabitTestExpense(t, ctx, b, userID, "Later beans", "7.00", createdAt)
+
+		update := mocks.CallbackQueryUpdate(
+			habitTestChatID, userID, habitTestMessage,
+			fmt.Sprintf("%s%d", reviewLaterPrefix, expense.ID),
+		)
+		b.handleReviewCallbackCore(ctx, mockBot, update)
+
+		require.Equal(t, 1, mockBot.AnsweredCallbackCount())
+		require.Equal(t, 1, mockBot.EditedMessageCount())
+		require.NotNil(t, mockBot.LastEditedMessage().ReplyMarkup)
+
+		unreviewed, err := b.expenseRepo.GetUnreviewedByUserID(ctx, userID, 10)
+		require.NoError(t, err)
+		require.Len(t, unreviewed, 1)
+	})
+
+	t.Run("callback on another user's expense is rejected", func(t *testing.T) {
+		mockBot := mocks.NewMockBot()
+		ownerID := int64(73402)
+		otherID := int64(73403)
+		upsertHabitTestUser(t, ctx, b, ownerID)
+		upsertHabitTestUser(t, ctx, b, otherID)
+		expense := createHabitTestExpense(t, ctx, b, ownerID, "Owned lunch", "9.00", createdAt)
+
+		update := mocks.CallbackQueryUpdate(
+			habitTestChatID, otherID, habitTestMessage,
+			fmt.Sprintf("%s%d", reviewWorthPrefix, expense.ID),
+		)
+		b.handleReviewCallbackCore(ctx, mockBot, update)
+
+		require.Equal(t, 1, mockBot.EditedMessageCount())
+		require.Equal(t, expenseNotFoundMsgCB, mockBot.LastEditedMessage().Text)
+	})
+
+	t.Run("driver callback with out-of-range index is ignored", func(t *testing.T) {
+		mockBot := mocks.NewMockBot()
+		userID := int64(73404)
+		upsertHabitTestUser(t, ctx, b, userID)
+		expense := createHabitTestExpense(t, ctx, b, userID, "Snack", "2.50", createdAt)
+
+		update := mocks.CallbackQueryUpdate(
+			habitTestChatID, userID, habitTestMessage,
+			fmt.Sprintf("%s%d_1_999", reviewDriverPrefix, expense.ID),
+		)
+		b.handleReviewCallbackCore(ctx, mockBot, update)
+
+		require.Equal(t, 1, mockBot.AnsweredCallbackCount())
+		require.Equal(t, 0, mockBot.EditedMessageCount())
+	})
+
+	t.Run("week period works", func(t *testing.T) {
+		mockBot := mocks.NewMockBot()
+		userID := int64(73405)
+		upsertHabitTestUser(t, ctx, b, userID)
+
+		b.handleHabitCore(ctx, mockBot, mocks.CommandUpdate(habitTestChatID, userID, "/habit week"))
+
+		require.Equal(t, 1, mockBot.SentMessageCount())
+		require.Contains(t, mockBot.LastSentMessage().Text, "This week")
+	})
+
+	t.Run("90d period summarizes reviewed expense", func(t *testing.T) {
+		mockBot := mocks.NewMockBot()
+		userID := int64(73406)
+		upsertHabitTestUser(t, ctx, b, userID)
+		expense := createHabitTestExpense(t, ctx, b, userID, "Quarterly taxi", "20.00", createdAt)
+		worth := true
+		require.NoError(t, b.expenseRepo.UpdateReflection(ctx, expense.ID, userID, &worth, "Necessity"))
+
+		b.handleHabitCore(ctx, mockBot, mocks.CommandUpdate(habitTestChatID, userID, "/habit 90d"))
+
+		require.Equal(t, 1, mockBot.SentMessageCount())
+		msg := mockBot.LastSentMessage()
+		require.Contains(t, msg.Text, "Last 90 days")
+		require.Contains(t, msg.Text, "Worth it: 1")
+		require.Contains(t, msg.Text, "Necessity")
+	})
+}

--- a/internal/bot/handlers_habit_test.go
+++ b/internal/bot/handlers_habit_test.go
@@ -188,6 +188,46 @@ func TestHandleReviewCallbackCore(t *testing.T) {
 		require.Equal(t, newer.ID, unreviewed[0].ID)
 	})
 
+	t.Run("later preserves message text and restores actions", func(t *testing.T) {
+		mockBot := mocks.NewMockBot()
+		userID := int64(73205)
+		upsertHabitTestUser(t, ctx, b, userID)
+		expense := createHabitTestExpense(
+			t,
+			ctx,
+			b,
+			userID,
+			"Later coffee",
+			"7.50",
+			time.Date(2026, 6, 16, 11, 0, 0, 0, time.UTC),
+		)
+
+		originalText := "<b>Saved expense</b> with <i>tags</i> intact."
+		update := &tgmodels.Update{
+			CallbackQuery: &tgmodels.CallbackQuery{
+				ID:   "callback-query-id",
+				From: tgmodels.User{ID: userID},
+				Message: tgmodels.MaybeInaccessibleMessage{
+					Type: tgmodels.MaybeInaccessibleMessageTypeMessage,
+					Message: &tgmodels.Message{
+						ID:   habitTestMessage,
+						Chat: tgmodels.Chat{ID: habitTestChatID, Type: "private"},
+						Text: originalText,
+					},
+				},
+				Data: fmt.Sprintf("%s%d", reviewLaterPrefix, expense.ID),
+			},
+		}
+
+		b.handleReviewCallbackCore(ctx, mockBot, update)
+
+		require.Equal(t, 1, mockBot.AnsweredCallbackCount())
+		require.Equal(t, 1, mockBot.EditedMessageCount())
+		msg := mockBot.LastEditedMessage()
+		require.Equal(t, originalText, msg.Text)
+		require.Equal(t, buildExpenseActionKeyboard(expense.ID), msg.ReplyMarkup)
+	})
+
 	t.Run("skip last expense shows done", func(t *testing.T) {
 		mockBot := mocks.NewMockBot()
 		userID := int64(73204)

--- a/internal/bot/handlers_habit_test.go
+++ b/internal/bot/handlers_habit_test.go
@@ -1,0 +1,335 @@
+package bot
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	tgmodels "github.com/go-telegram/bot/models"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/require"
+	"gitlab.com/yelinaung/expense-bot/internal/bot/mocks"
+	appmodels "gitlab.com/yelinaung/expense-bot/internal/models"
+)
+
+const (
+	habitTestChatID   = int64(73001)
+	habitTestMessage  = 44
+	habitTestTimezone = "UTC"
+)
+
+func TestHandleReviewCore(t *testing.T) {
+	ctx := context.Background()
+	pool := testDB(ctx, t)
+	b := setupTestBot(t, pool)
+
+	t.Run("no expenses", func(t *testing.T) {
+		mockBot := mocks.NewMockBot()
+		userID := int64(73101)
+		upsertHabitTestUser(t, ctx, b, userID)
+
+		b.handleReviewCore(ctx, mockBot, mocks.CommandUpdate(habitTestChatID, userID, "/review"))
+
+		require.Equal(t, 1, mockBot.SentMessageCount())
+		require.Contains(t, mockBot.LastSentMessage().Text, "No expenses to review.")
+	})
+
+	t.Run("with unreviewed expense", func(t *testing.T) {
+		mockBot := mocks.NewMockBot()
+		userID := int64(73102)
+		upsertHabitTestUser(t, ctx, b, userID)
+		expense := createHabitTestExpense(
+			t,
+			ctx,
+			b,
+			userID,
+			"Review coffee",
+			"4.25",
+			time.Date(2026, 6, 12, 9, 0, 0, 0, time.UTC),
+		)
+
+		b.handleReviewCore(ctx, mockBot, mocks.CommandUpdate(habitTestChatID, userID, "/review"))
+
+		require.Equal(t, 1, mockBot.SentMessageCount())
+		msg := mockBot.LastSentMessage()
+		require.Contains(t, msg.Text, "Was this worth it?")
+		require.Contains(t, msg.Text, expense.Description)
+		keyboard := requireInlineKeyboard(t, msg.ReplyMarkup)
+		require.Equal(t, fmt.Sprintf("%s%d", reviewWorthPrefix, expense.ID), keyboard.InlineKeyboard[0][0].CallbackData)
+		require.Equal(t, fmt.Sprintf("%s%d", reviewNotWorthPrefix, expense.ID), keyboard.InlineKeyboard[0][1].CallbackData)
+		require.Equal(t, fmt.Sprintf("%s%d", reviewSkipPrefix, expense.ID), keyboard.InlineKeyboard[1][0].CallbackData)
+	})
+}
+
+func TestHandleReviewCallbackCore(t *testing.T) {
+	ctx := context.Background()
+	pool := testDB(ctx, t)
+	b := setupTestBot(t, pool)
+
+	t.Run("worth-it callback asks for driver", func(t *testing.T) {
+		mockBot := mocks.NewMockBot()
+		userID := int64(73201)
+		upsertHabitTestUser(t, ctx, b, userID)
+		expense := createHabitTestExpense(
+			t,
+			ctx,
+			b,
+			userID,
+			"Driver prompt coffee",
+			"6.20",
+			time.Date(2026, 6, 13, 10, 0, 0, 0, time.UTC),
+		)
+
+		update := mocks.CallbackQueryUpdate(
+			habitTestChatID,
+			userID,
+			habitTestMessage,
+			fmt.Sprintf("%s%d", reviewWorthPrefix, expense.ID),
+		)
+		b.handleReviewCallbackCore(ctx, mockBot, update)
+
+		require.Equal(t, 1, mockBot.AnsweredCallbackCount())
+		require.Equal(t, 1, mockBot.EditedMessageCount())
+		msg := mockBot.LastEditedMessage()
+		require.Contains(t, msg.Text, "What drove this spend?")
+		keyboard := requireInlineKeyboard(t, msg.ReplyMarkup)
+		require.Equal(t, fmt.Sprintf("%s%d_1_0", reviewDriverPrefix, expense.ID), keyboard.InlineKeyboard[0][0].CallbackData)
+	})
+
+	t.Run("driver callback saves reflection and advances", func(t *testing.T) {
+		mockBot := mocks.NewMockBot()
+		userID := int64(73202)
+		upsertHabitTestUser(t, ctx, b, userID)
+		newer := createHabitTestExpense(
+			t,
+			ctx,
+			b,
+			userID,
+			"Newer reviewed coffee",
+			"8.00",
+			time.Date(2026, 6, 14, 10, 0, 0, 0, time.UTC),
+		)
+		older := createHabitTestExpense(
+			t,
+			ctx,
+			b,
+			userID,
+			"Older next lunch",
+			"12.00",
+			time.Date(2026, 6, 13, 10, 0, 0, 0, time.UTC),
+		)
+
+		update := mocks.CallbackQueryUpdate(
+			habitTestChatID,
+			userID,
+			habitTestMessage,
+			fmt.Sprintf("%s%d_1_0", reviewDriverPrefix, newer.ID),
+		)
+		b.handleReviewCallbackCore(ctx, mockBot, update)
+
+		require.Equal(t, 1, mockBot.AnsweredCallbackCount())
+		require.Equal(t, 1, mockBot.EditedMessageCount())
+		require.Contains(t, mockBot.LastEditedMessage().Text, older.Description)
+
+		reviewed, err := b.expenseRepo.GetReviewedByUserIDAndDateRange(
+			ctx,
+			userID,
+			time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC),
+			time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC),
+		)
+		require.NoError(t, err)
+		require.Len(t, reviewed, 1)
+		require.Equal(t, newer.ID, reviewed[0].ID)
+		require.NotNil(t, reviewed[0].WorthIt)
+		require.True(t, *reviewed[0].WorthIt)
+		require.NotNil(t, reviewed[0].SpendDriver)
+		require.Equal(t, string(spendingDrivers[0]), *reviewed[0].SpendDriver)
+	})
+
+	t.Run("skip advances without marking reviewed", func(t *testing.T) {
+		mockBot := mocks.NewMockBot()
+		userID := int64(73203)
+		upsertHabitTestUser(t, ctx, b, userID)
+		newer := createHabitTestExpense(
+			t,
+			ctx,
+			b,
+			userID,
+			"Skipped newer taxi",
+			"15.00",
+			time.Date(2026, 6, 15, 10, 0, 0, 0, time.UTC),
+		)
+		older := createHabitTestExpense(
+			t,
+			ctx,
+			b,
+			userID,
+			"Older next train",
+			"3.00",
+			time.Date(2026, 6, 14, 10, 0, 0, 0, time.UTC),
+		)
+
+		update := mocks.CallbackQueryUpdate(
+			habitTestChatID,
+			userID,
+			habitTestMessage,
+			fmt.Sprintf("%s%d", reviewSkipPrefix, newer.ID),
+		)
+		b.handleReviewCallbackCore(ctx, mockBot, update)
+
+		require.Equal(t, 1, mockBot.AnsweredCallbackCount())
+		require.Equal(t, 1, mockBot.EditedMessageCount())
+		require.Contains(t, mockBot.LastEditedMessage().Text, older.Description)
+
+		unreviewed, err := b.expenseRepo.GetUnreviewedByUserID(ctx, userID, 10)
+		require.NoError(t, err)
+		require.Len(t, unreviewed, 2)
+		require.Equal(t, newer.ID, unreviewed[0].ID)
+	})
+
+	t.Run("skip last expense shows done", func(t *testing.T) {
+		mockBot := mocks.NewMockBot()
+		userID := int64(73204)
+		upsertHabitTestUser(t, ctx, b, userID)
+		expense := createHabitTestExpense(
+			t,
+			ctx,
+			b,
+			userID,
+			"Only unreviewed",
+			"2.00",
+			time.Date(2026, 6, 16, 10, 0, 0, 0, time.UTC),
+		)
+
+		update := mocks.CallbackQueryUpdate(
+			habitTestChatID,
+			userID,
+			habitTestMessage,
+			fmt.Sprintf("%s%d", reviewSkipPrefix, expense.ID),
+		)
+		b.handleReviewCallbackCore(ctx, mockBot, update)
+
+		require.Equal(t, 1, mockBot.AnsweredCallbackCount())
+		require.Equal(t, 1, mockBot.EditedMessageCount())
+		require.Equal(t, "No more expenses to review.", mockBot.LastEditedMessage().Text)
+	})
+}
+
+func TestHandleHabitCore(t *testing.T) {
+	ctx := context.Background()
+	pool := testDB(ctx, t)
+	b := setupTestBot(t, pool)
+	b.nowFunc = func() time.Time {
+		return time.Date(2026, 6, 16, 12, 0, 0, 0, time.UTC)
+	}
+
+	t.Run("default period summarizes month", func(t *testing.T) {
+		mockBot := mocks.NewMockBot()
+		userID := int64(73301)
+		upsertHabitTestUser(t, ctx, b, userID)
+		reviewedExpense := createHabitTestExpense(
+			t,
+			ctx,
+			b,
+			userID,
+			"Reviewed June coffee",
+			"9.50",
+			time.Date(2026, 6, 8, 10, 0, 0, 0, time.UTC),
+		)
+		createHabitTestExpense(
+			t,
+			ctx,
+			b,
+			userID,
+			"Unreviewed June lunch",
+			"11.00",
+			time.Date(2026, 6, 9, 10, 0, 0, 0, time.UTC),
+		)
+		worthIt := true
+		require.NoError(t, b.expenseRepo.UpdateReflection(ctx, reviewedExpense.ID, userID, &worthIt, "Necessity"))
+
+		b.handleHabitCore(ctx, mockBot, mocks.CommandUpdate(habitTestChatID, userID, "/habit"))
+
+		require.Equal(t, 1, mockBot.SentMessageCount())
+		msg := mockBot.LastSentMessage()
+		require.Contains(t, msg.Text, "Spending Reflection")
+		require.Contains(t, msg.Text, "June 2026")
+		require.Contains(t, msg.Text, "Reviewed: 1/2")
+		require.Contains(t, msg.Text, "Worth it: 1")
+		require.Contains(t, msg.Text, "SGD: S$9.50")
+	})
+
+	t.Run("invalid period", func(t *testing.T) {
+		mockBot := mocks.NewMockBot()
+		userID := int64(73302)
+		upsertHabitTestUser(t, ctx, b, userID)
+
+		b.handleHabitCore(ctx, mockBot, mocks.CommandUpdate(habitTestChatID, userID, "/habit yearly"))
+
+		require.Equal(t, 1, mockBot.SentMessageCount())
+		require.Contains(t, mockBot.LastSentMessage().Text, "Invalid habit period")
+	})
+
+	t.Run("no data", func(t *testing.T) {
+		mockBot := mocks.NewMockBot()
+		userID := int64(73303)
+		upsertHabitTestUser(t, ctx, b, userID)
+
+		b.handleHabitCore(ctx, mockBot, mocks.CommandUpdate(habitTestChatID, userID, "/habit"))
+
+		require.Equal(t, 1, mockBot.SentMessageCount())
+		msg := mockBot.LastSentMessage()
+		require.Contains(t, msg.Text, "Reviewed: 0/0")
+		require.Contains(t, msg.Text, "Worth-it spend:\n  None")
+		require.Contains(t, msg.Text, "Best-value category: Not enough data")
+	})
+}
+
+func upsertHabitTestUser(t *testing.T, ctx context.Context, b *Bot, userID int64) {
+	t.Helper()
+
+	require.NoError(t, b.userRepo.UpsertUser(ctx, &appmodels.User{
+		ID:              userID,
+		Username:        fmt.Sprintf("habit%d", userID),
+		FirstName:       "Habit",
+		Timezone:        habitTestTimezone,
+		DefaultCurrency: testCurrencySGD,
+	}))
+}
+
+func createHabitTestExpense(
+	t *testing.T,
+	ctx context.Context,
+	b *Bot,
+	userID int64,
+	description string,
+	amount string,
+	createdAt time.Time,
+) *appmodels.Expense {
+	t.Helper()
+
+	expense := &appmodels.Expense{
+		UserID:      userID,
+		Amount:      decimal.RequireFromString(amount),
+		Currency:    testCurrencySGD,
+		Description: description,
+		Merchant:    description,
+		Status:      appmodels.ExpenseStatusConfirmed,
+	}
+	require.NoError(t, b.expenseRepo.Create(ctx, expense))
+	_, err := b.db.Exec(ctx, testUpdateExpenseTimeSQL, createdAt, expense.ID)
+	require.NoError(t, err)
+	expense.CreatedAt = createdAt
+
+	return expense
+}
+
+func requireInlineKeyboard(t *testing.T, markup tgmodels.ReplyMarkup) *tgmodels.InlineKeyboardMarkup {
+	t.Helper()
+
+	keyboard, ok := markup.(*tgmodels.InlineKeyboardMarkup)
+	require.True(t, ok, "expected inline keyboard markup")
+	require.NotNil(t, keyboard)
+	return keyboard
+}

--- a/internal/bot/handlers_habit_wrappers_test.go
+++ b/internal/bot/handlers_habit_wrappers_test.go
@@ -1,0 +1,62 @@
+package bot
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-telegram/bot"
+	"github.com/go-telegram/bot/models"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHabitHandlerWrappers covers the thin handler wrappers that exist only to
+// match the telegram bot library's expected signature. They delegate to the
+// Core functions, which return early on empty updates, so no bot/DB is needed.
+func TestHabitHandlerWrappers(t *testing.T) {
+	t.Parallel()
+
+	b := &Bot{}
+	ctx := context.Background()
+
+	var tgBot *bot.Bot
+
+	t.Run("handleReview wrapper - nil message", func(t *testing.T) {
+		t.Parallel()
+		b.handleReview(ctx, tgBot, &models.Update{})
+	})
+
+	t.Run("handleHabit wrapper - nil message", func(t *testing.T) {
+		t.Parallel()
+		b.handleHabit(ctx, tgBot, &models.Update{})
+	})
+
+	t.Run("handleReviewCallback wrapper - nil callback", func(t *testing.T) {
+		t.Parallel()
+		b.handleReviewCallback(ctx, tgBot, &models.Update{})
+	})
+}
+
+// TestParseDriverCallback_Malformed covers the parse failure branches that the
+// happy-path keyboard test does not reach.
+func TestParseDriverCallback_Malformed(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		data string
+	}{
+		{"too few parts", "review_driver_123_1"},
+		{"too many parts", "review_driver_123_1_0_4"},
+		{"non-numeric expense id", "review_driver_abc_1_0"},
+		{"invalid worth bit", "review_driver_123_2_0"},
+		{"non-numeric worth bit", "review_driver_123_x_0"},
+		{"non-numeric driver index", "review_driver_123_1_z"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.False(t, parseDriverCallback(tc.data).ok)
+		})
+	}
+}

--- a/internal/bot/handlers_receipt.go
+++ b/internal/bot/handlers_receipt.go
@@ -421,10 +421,11 @@ Expense #%d has been saved.`,
 		Msg("Expense confirmed via callback")
 
 	_, _ = tg.EditMessageText(ctx, &bot.EditMessageTextParams{
-		ChatID:    chatID,
-		MessageID: messageID,
-		Text:      text,
-		ParseMode: models.ParseModeHTML,
+		ChatID:      chatID,
+		MessageID:   messageID,
+		Text:        text,
+		ParseMode:   models.ParseModeHTML,
+		ReplyMarkup: buildExpenseReflectionKeyboard(expense.ID),
 	})
 }
 

--- a/internal/bot/mocks/bot_mock.go
+++ b/internal/bot/mocks/bot_mock.go
@@ -22,9 +22,10 @@ type TelegramAPI interface {
 
 // SentMessage captures a message sent via MockBot.
 type SentMessage struct {
-	ChatID    any
-	Text      string
-	ParseMode models.ParseMode
+	ChatID      any
+	Text        string
+	ParseMode   models.ParseMode
+	ReplyMarkup models.ReplyMarkup
 }
 
 // EditedMessage captures an edited message via MockBot.
@@ -102,9 +103,10 @@ func (m *MockBot) SendMessage(_ context.Context, params *bot.SendMessageParams) 
 	}
 
 	m.SentMessages = append(m.SentMessages, SentMessage{
-		ChatID:    params.ChatID,
-		Text:      params.Text,
-		ParseMode: params.ParseMode,
+		ChatID:      params.ChatID,
+		Text:        params.Text,
+		ParseMode:   params.ParseMode,
+		ReplyMarkup: params.ReplyMarkup,
 	})
 
 	msgID := m.NextMessageID

--- a/internal/bot/weekly_report.go
+++ b/internal/bot/weekly_report.go
@@ -187,7 +187,8 @@ func (b *Bot) sendWeeklySummary(
 	totalsByCurrency := sumExpenseAmountsByCurrency(expenses)
 	currencies := sortedCurrencyKeys(totalsByCurrency)
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "📊 <b>Weekly Expenses</b> (%s to %s)\n%d expenses",
+	fmt.Fprintf(
+		&sb, "📊 <b>Weekly Expenses</b> (%s to %s)\n%d expenses",
 		startOfWeek.Format("Jan 2"),
 		endOfWeek.AddDate(0, 0, -1).Format("Jan 2, 2006"),
 		len(expenses),

--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -139,6 +139,10 @@ func RunMigrations(ctx context.Context, pool *pgxpool.Pool) error {
 		)`,
 
 		`ALTER TABLE users ADD COLUMN IF NOT EXISTS timezone TEXT NOT NULL DEFAULT 'Asia/Singapore'`,
+
+		`ALTER TABLE expenses ADD COLUMN IF NOT EXISTS worth_it BOOLEAN`,
+		`ALTER TABLE expenses ADD COLUMN IF NOT EXISTS spend_driver TEXT`,
+		`ALTER TABLE expenses ADD COLUMN IF NOT EXISTS reviewed_at TIMESTAMPTZ`,
 	}
 
 	for i, migration := range migrations {
@@ -172,7 +176,8 @@ func SeedCategories(ctx context.Context, pool *pgxpool.Pool) error {
 	}
 
 	for _, cat := range categories {
-		_, err := pool.Exec(ctx,
+		_, err := pool.Exec(
+			ctx,
 			`INSERT INTO categories (name) VALUES ($1) ON CONFLICT (name) DO NOTHING`,
 			cat,
 		)

--- a/internal/database/migrations_comprehensive_test.go
+++ b/internal/database/migrations_comprehensive_test.go
@@ -121,6 +121,28 @@ func TestMigrations_SchemaDetails(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, exists, "expenses.status should exist as text")
 	})
+
+	t.Run("expenses table has reflection columns", func(t *testing.T) {
+		expectedColumns := map[string]string{
+			"worth_it":     "boolean",
+			"spend_driver": "text",
+			"reviewed_at":  "timestamp with time zone",
+		}
+
+		for columnName, dataType := range expectedColumns {
+			var exists bool
+			err := pool.QueryRow(ctx, `
+				SELECT EXISTS (
+					SELECT FROM information_schema.columns
+					WHERE table_name = 'expenses'
+					AND column_name = $1
+					AND data_type = $2
+				)
+			`, columnName, dataType).Scan(&exists)
+			require.NoError(t, err)
+			require.True(t, exists, "expenses.%s should exist as %s", columnName, dataType)
+		}
+	})
 }
 
 // TestMigrations_Indexes verifies all indexes are created.

--- a/internal/exchange/frankfurter_client.go
+++ b/internal/exchange/frankfurter_client.go
@@ -70,7 +70,8 @@ func (c *FrankfurterClient) Convert(
 		}, nil
 	}
 
-	endpoint := fmt.Sprintf("%s/latest?from=%s&to=%s",
+	endpoint := fmt.Sprintf(
+		"%s/latest?from=%s&to=%s",
 		c.baseURL,
 		url.QueryEscape(from),
 		url.QueryEscape(to),

--- a/internal/gemini/category_suggester.go
+++ b/internal/gemini/category_suggester.go
@@ -104,7 +104,8 @@ func (c *Client) SuggestCategory(ctx context.Context, description string, availa
 		},
 	}
 
-	ctx, span := geminiTracer.Start(ctx, "gemini.generate_content",
+	ctx, span := geminiTracer.Start(
+		ctx, "gemini.generate_content",
 		trace.WithAttributes(
 			attribute.String("gemini.model", ModelName),
 			attribute.String("gemini.operation", "suggest_category"),

--- a/internal/gemini/category_suggester_fuzz_test.go
+++ b/internal/gemini/category_suggester_fuzz_test.go
@@ -111,11 +111,13 @@ func FuzzSanitizeDescription(f *testing.F) {
 func assertSanitizedDescriptionInvariants(t *testing.T, input, result string) {
 	t.Helper()
 
-	assertDescriptionExcludesAny(t, input, result,
+	assertDescriptionExcludesAny(
+		t, input, result,
 		[]string{`"`, "`"},
 		[]string{"double quote", "backtick"},
 	)
-	assertDescriptionExcludesAny(t, input, result,
+	assertDescriptionExcludesAny(
+		t, input, result,
 		[]string{"\n", "\r", "\x00"},
 		[]string{"newline", "carriage return", "null byte"},
 	)
@@ -251,11 +253,13 @@ func FuzzSanitizeCategoryName(f *testing.F) {
 func assertSanitizedCategoryNameInvariants(t *testing.T, input, result string) {
 	t.Helper()
 
-	assertCategoryNameExcludesAny(t, input, result,
+	assertCategoryNameExcludesAny(
+		t, input, result,
 		[]string{`"`, "`"},
 		[]string{"double quote", "backtick"},
 	)
-	assertCategoryNameExcludesAny(t, input, result,
+	assertCategoryNameExcludesAny(
+		t, input, result,
 		[]string{"\n", "\r", "\x00"},
 		[]string{"newline", "carriage return", "null byte"},
 	)

--- a/internal/gemini/receipt_parser.go
+++ b/internal/gemini/receipt_parser.go
@@ -118,7 +118,8 @@ func (c *Client) ParseReceipt(ctx context.Context, imageBytes []byte, mimeType s
 		mimeType = "image/jpeg"
 	}
 
-	ctx, span := geminiTracer.Start(ctx, "gemini.generate_content",
+	ctx, span := geminiTracer.Start(
+		ctx, "gemini.generate_content",
 		trace.WithAttributes(
 			attribute.String("gemini.model", ModelName),
 			attribute.String("gemini.operation", "parse_receipt"),

--- a/internal/gemini/voice_parser.go
+++ b/internal/gemini/voice_parser.go
@@ -62,7 +62,8 @@ func (c *Client) ParseVoiceExpense(
 		mimeType = "audio/ogg"
 	}
 
-	ctx, span := geminiTracer.Start(ctx, "gemini.generate_content",
+	ctx, span := geminiTracer.Start(
+		ctx, "gemini.generate_content",
 		trace.WithAttributes(
 			attribute.String("gemini.model", ModelName),
 			attribute.String("gemini.operation", "parse_voice"),

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -100,6 +100,9 @@ type Expense struct {
 	Tags              []Tag
 	ReceiptFileID     string
 	Status            ExpenseStatus
+	WorthIt           *bool
+	SpendDriver       *string
+	ReviewedAt        *time.Time
 	CreatedAt         time.Time
 	UpdatedAt         time.Time
 }

--- a/internal/repository/expense_repository.go
+++ b/internal/repository/expense_repository.go
@@ -2,8 +2,12 @@ package repository
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 	"time"
+
+	"github.com/jackc/pgx/v5"
 
 	"github.com/shopspring/decimal"
 	"gitlab.com/yelinaung/expense-bot/internal/database"
@@ -31,7 +35,8 @@ func (r *ExpenseRepository) Create(ctx context.Context, expense *models.Expense)
 	if expense.Status == models.ExpenseStatusUnset {
 		expense.Status = models.ExpenseStatusConfirmed
 	}
-	err := r.db.QueryRow(ctx, `
+	err := r.db.QueryRow(
+		ctx, `
 		INSERT INTO expenses (user_id, amount, currency, description, merchant, category_id, receipt_file_id, status)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 		RETURNING id, user_expense_number, created_at, updated_at
@@ -182,6 +187,36 @@ func (r *ExpenseRepository) Update(ctx context.Context, expense *models.Expense)
 	return nil
 }
 
+// UpdateReflection stores a user reflection for an expense.
+func (r *ExpenseRepository) UpdateReflection(
+	ctx context.Context,
+	expenseID int,
+	userID int64,
+	worthIt *bool,
+	driver string,
+) error {
+	var driverValue *string
+	if strings.TrimSpace(driver) != "" {
+		driverValue = &driver
+	}
+
+	result, err := r.db.Exec(ctx, `
+		UPDATE expenses SET
+			worth_it = $3,
+			spend_driver = $4,
+			reviewed_at = NOW(),
+			updated_at = NOW()
+		WHERE id = $1 AND user_id = $2
+	`, expenseID, userID, worthIt, driverValue)
+	if err != nil {
+		return fmt.Errorf("failed to update expense reflection: %w", err)
+	}
+	if result.RowsAffected() == 0 {
+		return errors.New("failed to update expense reflection: no matching expense")
+	}
+	return nil
+}
+
 // Delete removes an expense by ID.
 func (r *ExpenseRepository) Delete(ctx context.Context, id int) error {
 	_, err := r.db.Exec(ctx, `DELETE FROM expenses WHERE id = $1`, id)
@@ -203,6 +238,91 @@ func (r *ExpenseRepository) DeleteExpiredDrafts(ctx context.Context, olderThan t
 		return 0, fmt.Errorf("failed to delete expired drafts: %w", err)
 	}
 	return int(result.RowsAffected()), nil
+}
+
+// GetUnreviewedByUserID retrieves confirmed expenses that have not been reviewed.
+func (r *ExpenseRepository) GetUnreviewedByUserID(ctx context.Context, userID int64, limit int) ([]models.Expense, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT e.id, e.user_expense_number, e.user_id, e.amount, e.currency, e.description, e.merchant, e.category_id,
+		       e.receipt_file_id, e.status, e.worth_it, e.spend_driver, e.reviewed_at, e.created_at, e.updated_at,
+		       c.id, c.name, c.created_at
+		FROM expenses e
+		LEFT JOIN categories c ON e.category_id = c.id
+		WHERE e.user_id = $1 AND e.status = $2 AND e.reviewed_at IS NULL
+		ORDER BY e.created_at DESC, e.id DESC
+		LIMIT $3
+	`, userID, models.ExpenseStatusConfirmed, limit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query unreviewed expenses: %w", err)
+	}
+	defer rows.Close()
+
+	return scanExpensesWithReflection(rows)
+}
+
+// GetNextUnreviewedByUserID retrieves the next unreviewed expense after a cursor.
+func (r *ExpenseRepository) GetNextUnreviewedByUserID(ctx context.Context, userID int64, afterExpenseID int) (*models.Expense, error) {
+	var currentCreatedAt time.Time
+	if err := r.db.QueryRow(ctx, `
+		SELECT created_at FROM expenses
+		WHERE id = $1 AND user_id = $2
+	`, afterExpenseID, userID).Scan(&currentCreatedAt); err != nil {
+		return nil, fmt.Errorf("failed to get current expense cursor: %w", err)
+	}
+
+	rows, err := r.db.Query(ctx, `
+		SELECT e.id, e.user_expense_number, e.user_id, e.amount, e.currency, e.description, e.merchant, e.category_id,
+		       e.receipt_file_id, e.status, e.worth_it, e.spend_driver, e.reviewed_at, e.created_at, e.updated_at,
+		       c.id, c.name, c.created_at
+		FROM expenses e
+		LEFT JOIN categories c ON e.category_id = c.id
+		WHERE e.user_id = $1
+		  AND e.status = $2
+		  AND e.reviewed_at IS NULL
+		  AND (e.created_at < $3 OR (e.created_at = $3 AND e.id < $4))
+		ORDER BY e.created_at DESC, e.id DESC
+		LIMIT 1
+	`, userID, models.ExpenseStatusConfirmed, currentCreatedAt, afterExpenseID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query next unreviewed expense: %w", err)
+	}
+	defer rows.Close()
+
+	expenses, err := scanExpensesWithReflection(rows)
+	if err != nil {
+		return nil, err
+	}
+	if len(expenses) == 0 {
+		return nil, fmt.Errorf("failed to get next unreviewed expense: %w", pgx.ErrNoRows)
+	}
+	return &expenses[0], nil
+}
+
+// GetReviewedByUserIDAndDateRange retrieves confirmed reflected expenses in a date range.
+func (r *ExpenseRepository) GetReviewedByUserIDAndDateRange(
+	ctx context.Context,
+	userID int64,
+	startDate, endDate time.Time,
+) ([]models.Expense, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT e.id, e.user_expense_number, e.user_id, e.amount, e.currency, e.description, e.merchant, e.category_id,
+		       e.receipt_file_id, e.status, e.worth_it, e.spend_driver, e.reviewed_at, e.created_at, e.updated_at,
+		       c.id, c.name, c.created_at
+		FROM expenses e
+		LEFT JOIN categories c ON e.category_id = c.id
+		WHERE e.user_id = $1
+		  AND e.created_at >= $2
+		  AND e.created_at < $3
+		  AND e.status = $4
+		  AND e.reviewed_at IS NOT NULL
+		ORDER BY e.created_at DESC, e.id DESC
+	`, userID, startDate, endDate, models.ExpenseStatusConfirmed)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query reviewed expenses by date range: %w", err)
+	}
+	defer rows.Close()
+
+	return scanExpensesWithReflection(rows)
 }
 
 // GetTotalByUserIDAndDateRange calculates total spending for confirmed expenses in a date range.
@@ -283,6 +403,50 @@ func scanExpenses(rows interface {
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("error iterating expenses: %w", err)
+	}
+	return expenses, nil
+}
+
+// scanExpensesWithReflection scans expense rows with category and reflection data.
+func scanExpensesWithReflection(rows interface {
+	Next() bool
+	Scan(dest ...any) error
+	Err() error
+},
+) ([]models.Expense, error) {
+	var expenses []models.Expense
+	for rows.Next() {
+		var exp models.Expense
+		var categoryID, catID *int
+		var worthIt *bool
+		var spendDriver *string
+		var reviewedAt *time.Time
+		var catName *string
+		var catCreatedAt *time.Time
+
+		if err := rows.Scan(
+			&exp.ID, &exp.UserExpenseNumber, &exp.UserID, &exp.Amount, &exp.Currency, &exp.Description,
+			&exp.Merchant, &categoryID, &exp.ReceiptFileID, &exp.Status, &worthIt, &spendDriver, &reviewedAt,
+			&exp.CreatedAt, &exp.UpdatedAt, &catID, &catName, &catCreatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("failed to scan expense with reflection: %w", err)
+		}
+
+		exp.CategoryID = categoryID
+		exp.WorthIt = worthIt
+		exp.SpendDriver = spendDriver
+		exp.ReviewedAt = reviewedAt
+		if catID != nil {
+			exp.Category = &models.Category{
+				ID:        *catID,
+				Name:      *catName,
+				CreatedAt: *catCreatedAt,
+			}
+		}
+		expenses = append(expenses, exp)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating expenses with reflection: %w", err)
 	}
 	return expenses, nil
 }

--- a/internal/repository/expense_repository.go
+++ b/internal/repository/expense_repository.go
@@ -206,8 +206,8 @@ func (r *ExpenseRepository) UpdateReflection(
 			spend_driver = $4,
 			reviewed_at = NOW(),
 			updated_at = NOW()
-		WHERE id = $1 AND user_id = $2
-	`, expenseID, userID, worthIt, driverValue)
+		WHERE id = $1 AND user_id = $2 AND status = $5
+	`, expenseID, userID, worthIt, driverValue, models.ExpenseStatusConfirmed)
 	if err != nil {
 		return fmt.Errorf("failed to update expense reflection: %w", err)
 	}

--- a/internal/repository/expense_repository.go
+++ b/internal/repository/expense_repository.go
@@ -408,6 +408,7 @@ func scanExpenses(rows interface {
 }
 
 // scanExpensesWithReflection scans expense rows with category and reflection data.
+// TODO: Unify this with scanExpenses after reflection columns are selected everywhere.
 func scanExpensesWithReflection(rows interface {
 	Next() bool
 	Scan(dest ...any) error

--- a/internal/repository/expense_repository_test.go
+++ b/internal/repository/expense_repository_test.go
@@ -765,6 +765,13 @@ func TestExpenseRepository_ReflectionWorkflow(t *testing.T) {
 	err = expenseRepo.UpdateReflection(ctx, newer.ID, otherUser.ID, &worth, "Necessity")
 	require.Error(t, err)
 
+	err = expenseRepo.UpdateReflection(ctx, draft.ID, user.ID, &worth, "Necessity")
+	require.Error(t, err)
+	var draftReviewedAt *time.Time
+	err = expenseRepo.Pool().QueryRow(ctx, `SELECT reviewed_at FROM expenses WHERE id = $1`, draft.ID).Scan(&draftReviewedAt)
+	require.NoError(t, err)
+	require.Nil(t, draftReviewedAt)
+
 	err = expenseRepo.UpdateReflection(ctx, newer.ID, user.ID, &worth, "Necessity")
 	require.NoError(t, err)
 

--- a/internal/repository/expense_repository_test.go
+++ b/internal/repository/expense_repository_test.go
@@ -700,3 +700,95 @@ func TestExpenseRepository_NullifyCategoryOnExpenses(t *testing.T) {
 		require.Equal(t, otherCat.ID, *fetched.CategoryID)
 	})
 }
+
+func TestExpenseRepository_ReflectionWorkflow(t *testing.T) {
+	expenseRepo, userRepo, categoryRepo, ctx := setupExpenseTest(t)
+
+	user := &models.User{ID: 980, Username: "reflectionuser", FirstName: testFirstName, LastName: testLastName}
+	err := userRepo.UpsertUser(ctx, user)
+	require.NoError(t, err)
+	otherUser := &models.User{ID: 981, Username: "otherreflection", FirstName: testFirstName, LastName: testLastName}
+	err = userRepo.UpsertUser(ctx, otherUser)
+	require.NoError(t, err)
+
+	cat, err := categoryRepo.Create(ctx, "Reflection Test Category")
+	require.NoError(t, err)
+
+	newer := &models.Expense{
+		UserID:      user.ID,
+		Amount:      decimal.RequireFromString("12.40"),
+		Currency:    testCurrencySGD,
+		Description: "Newer reflection",
+		CategoryID:  &cat.ID,
+		Status:      models.ExpenseStatusConfirmed,
+	}
+	err = expenseRepo.Create(ctx, newer)
+	require.NoError(t, err)
+
+	older := &models.Expense{
+		UserID:      user.ID,
+		Amount:      decimal.RequireFromString("9.10"),
+		Currency:    "USD",
+		Description: "Older reflection",
+		Status:      models.ExpenseStatusConfirmed,
+	}
+	err = expenseRepo.Create(ctx, older)
+	require.NoError(t, err)
+
+	draft := &models.Expense{
+		UserID:      user.ID,
+		Amount:      decimal.RequireFromString("3.00"),
+		Currency:    testCurrencySGD,
+		Description: "Draft reflection",
+		Status:      models.ExpenseStatusDraft,
+	}
+	err = expenseRepo.Create(ctx, draft)
+	require.NoError(t, err)
+
+	baseTime := time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)
+	_, err = expenseRepo.Pool().Exec(ctx, `UPDATE expenses SET created_at = $1 WHERE id = $2`, baseTime, newer.ID)
+	require.NoError(t, err)
+	_, err = expenseRepo.Pool().Exec(ctx, `UPDATE expenses SET created_at = $1 WHERE id = $2`, baseTime.Add(-time.Minute), older.ID)
+	require.NoError(t, err)
+	_, err = expenseRepo.Pool().Exec(ctx, `UPDATE expenses SET created_at = $1 WHERE id = $2`, baseTime.Add(time.Minute), draft.ID)
+	require.NoError(t, err)
+
+	unreviewed, err := expenseRepo.GetUnreviewedByUserID(ctx, user.ID, 10)
+	require.NoError(t, err)
+	require.Len(t, unreviewed, 2)
+	require.Equal(t, newer.ID, unreviewed[0].ID)
+	require.Equal(t, older.ID, unreviewed[1].ID)
+	require.NotNil(t, unreviewed[0].Category)
+	require.Equal(t, "Reflection Test Category", unreviewed[0].Category.Name)
+
+	worth := true
+	err = expenseRepo.UpdateReflection(ctx, newer.ID, otherUser.ID, &worth, "Necessity")
+	require.Error(t, err)
+
+	err = expenseRepo.UpdateReflection(ctx, newer.ID, user.ID, &worth, "Necessity")
+	require.NoError(t, err)
+
+	next, err := expenseRepo.GetNextUnreviewedByUserID(ctx, user.ID, newer.ID)
+	require.NoError(t, err)
+	require.Equal(t, older.ID, next.ID)
+
+	notWorth := false
+	err = expenseRepo.UpdateReflection(ctx, older.ID, user.ID, &notWorth, "")
+	require.NoError(t, err)
+
+	reviewed, err := expenseRepo.GetReviewedByUserIDAndDateRange(ctx, user.ID, baseTime.Add(-time.Hour), baseTime.Add(time.Hour))
+	require.NoError(t, err)
+	require.Len(t, reviewed, 2)
+	require.NotNil(t, reviewed[0].WorthIt)
+	require.True(t, *reviewed[0].WorthIt)
+	require.NotNil(t, reviewed[0].SpendDriver)
+	require.Equal(t, "Necessity", *reviewed[0].SpendDriver)
+	require.NotNil(t, reviewed[0].ReviewedAt)
+	require.NotNil(t, reviewed[1].WorthIt)
+	require.False(t, *reviewed[1].WorthIt)
+	require.Nil(t, reviewed[1].SpendDriver)
+
+	unreviewed, err = expenseRepo.GetUnreviewedByUserID(ctx, user.ID, 10)
+	require.NoError(t, err)
+	require.Empty(t, unreviewed)
+}

--- a/internal/telemetry/middleware.go
+++ b/internal/telemetry/middleware.go
@@ -31,7 +31,8 @@ func TracingMiddleware(metrics *BotMetrics) func(next bot.HandlerFunc) bot.Handl
 			spanName := classifyUpdate(update)
 			attrs := updateAttributes(update)
 
-			ctx, span := tracer.Start(ctx, spanName,
+			ctx, span := tracer.Start(
+				ctx, spanName,
 				trace.WithSpanKind(trace.SpanKindServer),
 				trace.WithAttributes(attrs...),
 			)
@@ -131,29 +132,35 @@ func updateAttributes(update *models.Update) []attribute.KeyValue {
 
 	switch {
 	case update.Message != nil:
-		attrs = append(attrs,
+		attrs = append(
+			attrs,
 			attribute.String(telegramChatId, logger.HashChatID(update.Message.Chat.ID)),
 		)
 		if update.Message.From != nil {
-			attrs = append(attrs,
+			attrs = append(
+				attrs,
 				attribute.String(telegramUserId, logger.HashUserID(update.Message.From.ID)),
 			)
 		}
 	case update.CallbackQuery != nil:
-		attrs = append(attrs,
+		attrs = append(
+			attrs,
 			attribute.String(telegramUserId, logger.HashUserID(update.CallbackQuery.From.ID)),
 		)
 		if update.CallbackQuery.Message.Message != nil {
-			attrs = append(attrs,
+			attrs = append(
+				attrs,
 				attribute.String(telegramChatId, logger.HashChatID(update.CallbackQuery.Message.Message.Chat.ID)),
 			)
 		}
 	case update.EditedMessage != nil:
-		attrs = append(attrs,
+		attrs = append(
+			attrs,
 			attribute.String(telegramChatId, logger.HashChatID(update.EditedMessage.Chat.ID)),
 		)
 		if update.EditedMessage.From != nil {
-			attrs = append(attrs,
+			attrs = append(
+				attrs,
 				attribute.String(telegramUserId, logger.HashUserID(update.EditedMessage.From.ID)),
 			)
 		}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -71,7 +71,8 @@ func Init(ctx context.Context, cfg *Config) (*Providers, error) {
 		return nil, err
 	}
 
-	res, err := resource.New(ctx,
+	res, err := resource.New(
+		ctx,
 		resource.WithAttributes(
 			semconv.ServiceName(cfg.ServiceName),
 			semconv.ServiceVersion(cfg.ServiceVersion),

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -11,7 +11,7 @@ ARG GITLEAKS_VERSION=8.30.1
 ARG SEMGREP_VERSION=1.164.0
 ARG MISE_VERSION=2026.5.16
 # renovate: datasource=github-commits depName=golangci/golangci-lint
-ARG GOLANGCI_LINT_INSTALL_COMMIT=870ddc133592c3609f26af3b6f05ce2dd4a7afda
+ARG GOLANGCI_LINT_INSTALL_COMMIT=2c56c9c84fbfa69db9c3fa70b0cc763d6d1a1746
 # renovate: datasource=github-commits depName=securego/gosec
 ARG GOSEC_INSTALL_COMMIT=5f4eec95fa28ce5dc6cf555de8c242cb57545f01
 
@@ -44,7 +44,7 @@ RUN pipx install semgrep=="${SEMGREP_VERSION}" && \
     curl --proto "=https" --tlsv1.2 -sSf -L \
       "https://raw.githubusercontent.com/golangci/golangci-lint/${GOLANGCI_LINT_INSTALL_COMMIT}/install.sh" \
       -o /tmp/golangci-lint-install.sh && \
-    sh /tmp/golangci-lint-install.sh -- -b "${GOBIN}" "v${GOLANGCI_LINT_VERSION}" && \
+    sh /tmp/golangci-lint-install.sh -b "${GOBIN}" "v${GOLANGCI_LINT_VERSION}" && \
     rm /tmp/golangci-lint-install.sh && \
     curl --proto "=https" --tlsv1.2 -sSf -L "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | \
     tar -xz -C /usr/local/bin gitleaks && \

--- a/runner/docker-compose.yml
+++ b/runner/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       RUNNER_NAME: expense-bot-runner1
       RUNNER_WORKDIR: /tmp/github-runner-expense-bot
       LABELS: 'playground-ubuntu,self-hosted'
+      EPHEMERAL: 'true'
     volumes:
       - '/var/run/docker.sock:/var/run/docker.sock'
       - 'runner1-work:/tmp/github-runner-expense-bot'
@@ -22,6 +23,7 @@ services:
       RUNNER_NAME: expense-bot-runner2
       RUNNER_WORKDIR: /tmp/github-runner-expense-bot
       LABELS: 'playground-ubuntu,self-hosted'
+      EPHEMERAL: 'true'
     volumes:
       - '/var/run/docker.sock:/var/run/docker.sock'
       - 'runner2-work:/tmp/github-runner-expense-bot'
@@ -35,6 +37,7 @@ services:
       RUNNER_NAME: expense-bot-runner3
       RUNNER_WORKDIR: /tmp/github-runner-expense-bot
       LABELS: 'playground-ubuntu,self-hosted'
+      EPHEMERAL: 'true'
     volumes:
       - '/var/run/docker.sock:/var/run/docker.sock'
       - 'runner3-work:/tmp/github-runner-expense-bot'
@@ -49,6 +52,7 @@ services:
       RUNNER_NAME: expense-bot-runner4
       RUNNER_WORKDIR: /tmp/github-runner-expense-bot
       LABELS: 'playground-ubuntu,self-hosted'
+      EPHEMERAL: 'true'
     volumes:
       - '/var/run/docker.sock:/var/run/docker.sock'
       - 'runner4-work:/tmp/github-runner-expense-bot'


### PR DESCRIPTION
## Summary by Sourcery

Add a spending reflection feature that lets users review expenses as worth it or not, capture drivers, and generate habit summaries over configurable periods, including all supporting schema, repository, bot handlers, tests, and runner tweaks.

New Features:
- Allow users to record per-expense reflections including whether a spend was worth it and what drove the purchase.
- Introduce /review and /habit bot commands to drive reflection workflows and generate period-based spending recap messages.
- Add inline reflection entry points to expense confirmation messages with follow-up prompts for spend drivers.

Enhancements:
- Extend expense models, repositories, and scanners to support reflection fields and new unreviewed/reviewed expense queries.
- Implement analysis utilities to aggregate reviewed expenses into multi-currency habit summaries with deterministic insights.
- Refine bot telemetry, tracing, and formatting for better readability and attribute capture.

Build:
- Update runner Dockerfile lint installation flags and golangci-lint commit reference.
- Configure GitHub runner docker-compose services to use ephemeral self-hosted runners.

CI:
- Mark self-hosted runners as ephemeral in the runner docker-compose configuration.

Deployment:
- Adjust runner configuration to better support disposable self-hosted GitHub runners.

Documentation:
- Add a detailed plan document describing the spending reflection feature scope, data model, flows, and testing strategy.

Tests:
- Add repository tests covering the full reflection workflow and reflection-aware expense scanning.
- Add analyzer and bot handler tests for habit summaries, callback flows, keyboards, and period handling.
- Extend migration tests to assert presence of new reflection columns on the expenses table.

Chores:
- Apply minor formatting and readability tweaks across telemetry, Gemini clients, and existing tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `/review` to step through unreviewed expenses with worth-it/not-worth-it and spending driver capture, with “skip” and “later” actions.
  * Added `/habit` to generate HTML summaries for week/month/90d, including best-value/most-regretted categories and spending insights (when available).
  * Added inline reflection prompts to the expense confirmation flow.
* **Documentation**
  * Added an MVP plan for the Spending Reflection Telegram bot.
* **Updates**
  * Extended expense storage and retrieval to track reflection status, driver, and review timestamps.
* **Tests**
  * Added unit and handler test coverage for review progression, callback payloads, habit summaries, and keyboard behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->