### PR TITLE
fix: preserve UTF-8 in SanitizeText and treat empty category names as…

### DIFF
--- a/docs/HEGEL_PBT_FINDINGS.md
+++ b/docs/HEGEL_PBT_FINDINGS.md
@@ -209,7 +209,7 @@ hit.
 
 ### Hegel counterexample
 
-```
+```text
 TestHegelGenerateExpensesCSVEmptyNameIsUncategorized
   nil Category     -> Category cell = "Uncategorized"
   &Category{Name:""} -> Category cell = ""          ← diverges

--- a/docs/HEGEL_PBT_FINDINGS.md
+++ b/docs/HEGEL_PBT_FINDINGS.md
@@ -1,0 +1,271 @@
+# Hegel Property-Based Testing Findings
+
+**Date**: 2026-06-18
+**Status**: Fixed — 3 bugs identified and patched; regression tests (Hegel PBTs + deterministic unit tests) added and passing
+
+---
+
+## Overview
+
+A pass of [Hegel](https://hegel.dev) property-based tests (PBTs) over
+previously unit-tested-only modules surfaced **3 real bugs**. Each bug was
+demonstrated by a Hegel test encoding the *correct* contract; the test
+initially failed on the buggy code and Hegel shrunk the input to a minimal
+counterexample. All three bugs are now fixed; the Hegel tests plus
+deterministic regression unit tests pass and serve as permanent regression
+markers.
+
+The tests were added alongside the existing tests for the code under test
+(see `AGENTS.md` / Hegel workflow — "Property-based tests belong with the
+code they're testing"):
+
+| File | Tests added |
+|------|-------------|
+| `internal/logger/privacy_rapid_test.go` | 3 |
+| `internal/bot/chart_generator_hegel_test.go` | 2 (new file) |
+| `internal/bot/csv_generator_rapid_test.go` | 2 (appended) |
+
+All 7 tests now pass after the fixes below; `go vet` and `gofumpt` are clean.
+Run them with:
+
+```sh
+GOCACHE=$PWD/.cache/go-build go test ./internal/logger/ ./internal/bot/ \
+  -run 'TestHegelSanitizeText|TestHegelAggregateByCategory|TestHegelGenerateExpensesCSVEmptyNameIsUncategorized|TestHegelGenerateExpensesCSVCategoryColumnConsistentWithHabitCategoryName'
+```
+
+---
+
+## Bug 1 — `SanitizeText` emits invalid UTF-8
+
+**Severity**: Medium (corrupts logs, can break log parsers / aggregators that
+require valid UTF-8).
+
+**File**: `internal/logger/privacy.go:78`
+
+```go
+// For longer text, show prefix and length
+return fmt.Sprintf("%s...<%d chars>", text[:3], len(text))
+```
+
+### Root cause
+
+The "long text" branch slices `text[:3]` by **byte index**, not by rune.
+When the first 3 bytes fall inside a multi-byte UTF-8 sequence (any non-ASCII
+character that encodes to 4 bytes, e.g. `𐀀`, `😀`, or a 3-byte CJK char
+preceded by 1 ASCII char), the slice cuts a rune in half and the resulting
+string is no longer valid UTF-8.
+
+A secondary issue: the label says `<N chars>` but `len(text)` reports the
+**byte** count, not the rune count — so the docstring ("show prefix and
+length") and the label disagree for non-ASCII input.
+
+### Why existing tests missed it
+
+`internal/logger/privacy_test.go` only exercises ASCII inputs
+(`"short"`, `"this is a long text"`). ASCII never spans a multi-byte
+boundary, so byte-index slicing happens to be rune-aligned.
+
+### Hegel counterexamples
+
+Hegel shrinks each failure to a minimal input:
+
+| Test | Minimal input | Output |
+|------|---------------|--------|
+| `TestHegelSanitizeTextOutputIsValidUTF8` | `"0𐀀\u0080𐀀"` | `"0\xf0\x9..."` — invalid UTF-8 |
+| `TestHegelSanitizeTextLongInputValidUTF8` | `"00\u008000000000"` (11 bytes) | `"00..."` prefix splits the rune |
+| `TestHegelSanitizeTextPrefixIsRuneAligned` | same as above | prefix `"00\..."` is not rune-aligned |
+
+### Fix
+
+Applied in `internal/logger/privacy.go`: slice by rune and report the rune
+count so the output stays valid UTF-8 and the `<N chars>` label matches its
+content.
+
+```go
+if len(text) <= 10 {
+    return fmt.Sprintf("<%d chars>", utf8.RuneCountInString(text))
+}
+runes := []rune(text)
+return fmt.Sprintf("%s...<%d chars>", string(runes[:3]), len(runes))
+```
+
+### Tests
+
+`internal/logger/privacy_rapid_test.go`:
+
+- `TestHegelSanitizeTextOutputIsValidUTF8` — `utf8.ValidString(SanitizeText(in))`
+  for any `hegel.Text()` input.
+- `TestHegelSanitizeTextLongInputValidUTF8` — focused on inputs ≥ 11 bytes
+  (the branch where the bug lives).
+- `TestHegelSanitizeTextPrefixIsRuneAligned` — the sharper property: the
+  exposed prefix must be a whole number of runes.
+
+---
+
+## Bug 2 — `aggregateByCategory` keys empty-named categories as `""`
+
+**Severity**: Low–Medium (incorrect chart grouping; empty category appears as
+a blank legend entry / unlabeled slice).
+
+**File**: `internal/bot/chart_generator.go:75`
+
+```go
+categoryName := categoryUncategorized
+if expenses[i].Category != nil {
+    categoryName = expenses[i].Category.Name
+}
+```
+
+### Root cause
+
+The function treats "no category" as *only* a nil `Category` pointer. A
+non-nil `Category` whose `Name` is the empty string falls through and becomes
+the map key `""` instead of `"Uncategorized"`.
+
+This is **inconsistent** with the rest of the bot: `habitCategoryName`
+(`internal/bot/habit_analyzer.go:117`) explicitly falls back to
+`categoryUncategorized` when `Category.Name == ""`, and
+`GenerateExpensesCSV` (Bug 3 below) shares the same defect. Two code paths
+that classify an expense's category therefore disagree on what "no category"
+means.
+
+### Why existing tests missed it
+
+`internal/bot/chart_generator_test.go` only constructs categories with
+non-empty names (`testCategoryFoodGroceries`, `testCategoryFoodDiningOut`)
+or `nil`. The `Category{Name: ""}` case is never exercised.
+
+### Hegel counterexample
+
+Hegel shrinks to the empty-name case directly:
+
+```
+TestHegelAggregateByCategoryEmptyNameIsUncategorized
+  expected: map[string]decimal.Decimal{"Uncategorized": ...}
+  actual  : map[string]decimal.Decimal{"": ...}
+```
+
+i.e. a nil `Category` aggregates under `"Uncategorized"` but a
+`&Category{Name: ""}` aggregates under `""`.
+
+### Fix
+
+Applied in `internal/bot/chart_generator.go`: also guard against an empty
+`Name` so empty-named categories fall back to `categoryUncategorized`,
+matching `habitCategoryName`.
+
+```go
+categoryName := categoryUncategorized
+if expenses[i].Category != nil && expenses[i].Category.Name != "" {
+    categoryName = expenses[i].Category.Name
+}
+```
+
+### Tests
+
+`internal/bot/chart_generator_hegel_test.go`:
+
+- `TestHegelAggregateByCategoryConsistentWithHabitCategoryName` — for any
+  `*Category` (nil / empty-name / non-empty-name), the map key used by
+  `aggregateByCategory` must equal `habitCategoryName(&expense)`.
+- `TestHegelAggregateByCategoryEmptyNameIsUncategorized` — the focused
+  counterexample: nil and empty-name must aggregate identically, and the key
+  must be `categoryUncategorized`.
+
+A shared generator `hegelCategoryOrNilGen` draws all three cases (nil,
+empty-name, non-empty-name) so the same coverage feeds Bug 3's tests too.
+
+---
+
+## Bug 3 — `GenerateExpensesCSV` writes an empty Category cell
+
+**Severity**: Low–Medium (CSV export shows a blank category column for
+empty-named categories, inconsistent with `nil` which shows
+`"Uncategorized"`; downstream consumers may treat the empty cell
+differently from the sentinel).
+
+**File**: `internal/bot/csv_generator.go:67`
+
+```go
+categoryName := categoryUncategorized
+if expenses[i].Category != nil {
+    categoryName = expenses[i].Category.Name
+}
+```
+
+### Root cause
+
+Identical to Bug 2: the `Category != nil` check does not account for an
+empty `Name`. The CSV's Category column therefore diverges from
+`habitCategoryName`'s notion of an expense's category.
+
+### Why existing tests missed it
+
+`internal/bot/csv_generator_rapid_test.go` had Hegel tests for the CSV
+generator (`TestHegelGenerateExpensesCSVStructure`,
+`TestHegelGenerateExpensesCSVNeutralizesFormulas`, …) but every generated
+expense left `Category` unset (i.e. `nil`). The empty-name branch was never
+hit.
+
+### Hegel counterexample
+
+```
+TestHegelGenerateExpensesCSVEmptyNameIsUncategorized
+  nil Category     -> Category cell = "Uncategorized"
+  &Category{Name:""} -> Category cell = ""          ← diverges
+```
+
+### Fix
+
+Applied in `internal/bot/csv_generator.go`: the same one-line guard as Bug 2
+(check `Name != ""`), so all three code paths (chart / CSV / habit analyzer)
+now agree on "no category" → `"Uncategorized"`.
+
+### Tests
+
+Appended to `internal/bot/csv_generator_rapid_test.go`:
+
+- `TestHegelGenerateExpensesCSVEmptyNameIsUncategorized` — focused
+  counterexample: nil and empty-name must produce the same Category cell,
+  and that cell must be `categoryUncategorized`.
+- `TestHegelGenerateExpensesCSVCategoryColumnConsistentWithHabitCategoryName`
+  — for any `*Category`, the CSV Category column equals
+  `habitCategoryName(&expense)`.
+
+A small helper `csvCategoryColumn(t, expense)` renders a single-expense CSV
+and returns the 7th column so both tests share the rendering logic.
+
+---
+
+## Summary
+
+| # | Bug | Location | Root cause | Tests |
+|---|-----|----------|------------|-------|
+| 1 | `SanitizeText` returns invalid UTF-8 | `internal/logger/privacy.go:78` | byte slice `text[:3]` splits a multi-byte rune; `<N chars>` label reports byte count | 3 |
+| 2 | `aggregateByCategory` keys empty-named categories as `""` | `internal/bot/chart_generator.go:75` | `Category != nil` check misses `Name == ""`; diverges from `habitCategoryName` | 2 |
+| 3 | `GenerateExpensesCSV` writes empty Category cell | `internal/bot/csv_generator.go:67` | same `Category != nil`-only check as Bug 2 | 2 |
+
+Bugs 2 and 3 share a root cause and a one-line fix. Bug 1 is independent.
+All three are now patched and covered by passing regression tests.
+
+### Notes on the testing approach
+
+- **Generators stayed broad.** Per Hegel's "Generator Discipline", no bounds
+  were added to avoid the bugs — `hegel.Text()` is full Unicode, and
+  `hegelCategoryOrNilGen` deliberately includes the empty-name case. The
+  edge cases are the *point*, not something to filter out.
+- **Properties are evidence-based.** Each property is grounded in the code's
+  own contract: `SanitizeText`'s docstring ("show prefix and length"),
+  `habitCategoryName`'s explicit fallback, and the existing
+  `"Uncategorized"` sentinel.
+- **No new test files where one existed.** The logger PBTs join a new file
+  (no rapid test existed there); the CSV PBTs were appended to the existing
+  `csv_generator_rapid_test.go`; the chart PBTs live in a new file because
+  no Hegel/rapid test file for `chart_generator.go` existed.
+- **The tests are kept as regression markers.** They initially failed on the
+  buggy code; after the fixes they pass and remain in the suite to prevent
+  regressions. Each bug also has a focused deterministic unit test
+  (`TestSanitizeText/"long multi-byte text produces valid UTF-8 prefix"`,
+  `TestAggregateByCategory/"treats empty category name as Uncategorized"`,
+  `TestGenerateExpensesCSV/"treats empty category name as Uncategorized"`)
+  so the fix is locked in without relying solely on the property harness.

--- a/internal/bot/chart_generator.go
+++ b/internal/bot/chart_generator.go
@@ -72,7 +72,7 @@ func aggregateByCategory(expenses []models.Expense) map[string]decimal.Decimal {
 
 	for i := range expenses {
 		categoryName := categoryUncategorized
-		if expenses[i].Category != nil {
+		if expenses[i].Category != nil && expenses[i].Category.Name != "" {
 			categoryName = expenses[i].Category.Name
 		}
 

--- a/internal/bot/chart_generator_hegel_test.go
+++ b/internal/bot/chart_generator_hegel_test.go
@@ -1,0 +1,73 @@
+package bot
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gitlab.com/yelinaung/expense-bot/internal/models"
+	"hegel.dev/go/hegel"
+)
+
+// hegelCategoryOrNilGen draws a *models.Category that exercises the
+// empty-name boundary: nil, a non-nil Category with an empty Name, or a
+// non-nil Category with a non-empty Name. The empty-Name case is the one
+// that distinguishes a correct "fall back to Uncategorized" implementation
+// from a buggy one that only checks Category != nil.
+func hegelCategoryOrNilGen() hegel.Generator[*models.Category] {
+	return hegel.Composite(func(tc hegel.TestCase) *models.Category {
+		kind := hegel.Draw(tc, hegel.Integers(0, 2))
+		switch kind {
+		case 0:
+			return nil
+		case 1:
+			return &models.Category{Name: ""}
+		default:
+			return &models.Category{Name: hegel.Draw(tc, hegelCategoryNameGen())}
+		}
+	})
+}
+
+// TestHegelAggregateByCategoryConsistentWithHabitCategoryName asserts that
+// the key aggregateByCategory uses for an expense matches the canonical
+// category name produced by habitCategoryName. Both functions classify an
+// expense's category, so they must agree on what "no category" means: a nil
+// Category and a Category with an empty Name should both map to
+// "Uncategorized". aggregateByCategory only checks Category != nil, so an
+// empty Name leaks through as the "" key instead of "Uncategorized".
+func TestHegelAggregateByCategoryConsistentWithHabitCategoryName(t *testing.T) {
+	t.Parallel()
+	hegel.Test(t, func(ht *hegel.T) {
+		cat := hegel.Draw(ht, hegelCategoryOrNilGen())
+		expense := models.Expense{
+			Amount:   hegel.Draw(ht, hegelAmountGen()),
+			Currency: hegel.Draw(ht, hegel.SampledFrom(expenseTestCurrencies)),
+			Category: cat,
+		}
+		result := aggregateByCategory([]models.Expense{expense})
+		wantKey := habitCategoryName(&expense)
+		_, ok := result[wantKey]
+		require.True(ht, ok,
+			"aggregateByCategory key %q missing (Category=%+v): got %v",
+			wantKey, cat, result)
+	})
+}
+
+// TestHegelAggregateByCategoryEmptyNameIsUncategorized is the focused
+// counterexample: a non-nil Category with an empty Name must aggregate under
+// "Uncategorized", exactly like a nil Category does.
+func TestHegelAggregateByCategoryEmptyNameIsUncategorized(t *testing.T) {
+	t.Parallel()
+	hegel.Test(t, func(ht *hegel.T) {
+		amount := hegel.Draw(ht, hegelAmountGen())
+		nilResult := aggregateByCategory([]models.Expense{
+			{Amount: amount, Currency: "SGD", Category: nil},
+		})
+		emptyResult := aggregateByCategory([]models.Expense{
+			{Amount: amount, Currency: "SGD", Category: &models.Category{Name: ""}},
+		})
+		require.Equal(ht, nilResult, emptyResult,
+			"nil Category and empty-name Category should aggregate identically")
+		require.Contains(ht, emptyResult, categoryUncategorized,
+			"empty-name Category should fall back to %q", categoryUncategorized)
+	})
+}

--- a/internal/bot/chart_generator_test.go
+++ b/internal/bot/chart_generator_test.go
@@ -200,6 +200,18 @@ func TestAggregateByCategory(t *testing.T) {
 			expenses: []models.Expense{},
 			expected: map[string]string{},
 		},
+		{
+			name: "treats empty category name as Uncategorized",
+			expenses: []models.Expense{
+				{
+					Amount:   decimal.NewFromFloat(15.00),
+					Category: &models.Category{Name: ""}, // Non-nil but empty name
+				},
+			},
+			expected: map[string]string{
+				"Uncategorized": "15",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/bot/csv_generator.go
+++ b/internal/bot/csv_generator.go
@@ -64,7 +64,7 @@ func GenerateExpensesCSV(expenses []models.Expense) ([]byte, error) {
 	// Write expense rows
 	for i := range expenses {
 		categoryName := categoryUncategorized
-		if expenses[i].Category != nil {
+		if expenses[i].Category != nil && expenses[i].Category.Name != "" {
 			categoryName = expenses[i].Category.Name
 		}
 

--- a/internal/bot/csv_generator_rapid_test.go
+++ b/internal/bot/csv_generator_rapid_test.go
@@ -261,3 +261,75 @@ func TestHegelGenerateExpensesCSVNeutralizesFormulas(t *testing.T) {
 		require.Equal(ht, "'"+injected, rows[1][5], "merchant cell")
 	})
 }
+
+// csvCategoryColumn renders a single-expense CSV and returns the Category
+// cell (the 7th column of the data row). Used by the empty-name property
+// tests below. The expense is passed by pointer because models.Expense is
+// large enough to trip gocritic's hugeParam check.
+func csvCategoryColumn(t require.TestingT, expense *models.Expense) string {
+	data, err := GenerateExpensesCSV([]models.Expense{*expense})
+	require.NoError(t, err)
+	reader := csv.NewReader(bytes.NewReader(data))
+	rows, err := reader.ReadAll()
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	require.Len(t, rows[1], 7)
+	return rows[1][6]
+}
+
+// TestHegelGenerateExpensesCSVEmptyNameIsUncategorized is the focused
+// counterexample: a non-nil Category with an empty Name must render the
+// Category column as "Uncategorized", exactly like a nil Category does.
+// GenerateExpensesCSV only checks Category != nil, so an empty Name leaks
+// through as an empty cell instead of "Uncategorized".
+func TestHegelGenerateExpensesCSVEmptyNameIsUncategorized(t *testing.T) {
+	t.Parallel()
+	hegel.Test(t, func(ht *hegel.T) {
+		amount := hegel.Draw(ht, hegelAmountGen())
+		cur := hegel.Draw(ht, hegel.SampledFrom(sortedSupportedCurrencyCodes()))
+		base := models.Expense{
+			UserExpenseNumber: 1,
+			Amount:            amount,
+			Currency:          cur,
+			CreatedAt:         hegel.Draw(ht, hegel.Datetimes()),
+		}
+
+		nilCell := csvCategoryColumn(ht, func() *models.Expense {
+			e := base
+			e.Category = nil
+			return &e
+		}())
+		emptyCell := csvCategoryColumn(ht, func() *models.Expense {
+			e := base
+			e.Category = &models.Category{Name: ""}
+			return &e
+		}())
+
+		require.Equal(ht, nilCell, emptyCell,
+			"nil Category and empty-name Category should render the same Category cell")
+		require.Equal(ht, categoryUncategorized, emptyCell,
+			"empty-name Category should render as %q, got %q", categoryUncategorized, emptyCell)
+	})
+}
+
+// TestHegelGenerateExpensesCSVCategoryColumnConsistentWithHabitCategoryName
+// asserts that the CSV Category column agrees with habitCategoryName's
+// notion of an expense's category. Both code paths classify categories, so a
+// nil Category and a Category with an empty Name must both yield
+// "Uncategorized" rather than diverging.
+func TestHegelGenerateExpensesCSVCategoryColumnConsistentWithHabitCategoryName(t *testing.T) {
+	t.Parallel()
+	hegel.Test(t, func(ht *hegel.T) {
+		cat := hegel.Draw(ht, hegelCategoryOrNilGen())
+		expense := models.Expense{
+			UserExpenseNumber: 1,
+			Amount:            hegel.Draw(ht, hegelAmountGen()),
+			Currency:          hegel.Draw(ht, hegel.SampledFrom(sortedSupportedCurrencyCodes())),
+			Category:          cat,
+			CreatedAt:         hegel.Draw(ht, hegel.Datetimes()),
+		}
+		got := csvCategoryColumn(ht, &expense)
+		require.Equal(ht, habitCategoryName(&expense), got,
+			"CSV Category column disagrees with habitCategoryName (Category=%+v)", cat)
+	})
+}

--- a/internal/bot/csv_generator_test.go
+++ b/internal/bot/csv_generator_test.go
@@ -94,6 +94,29 @@ func TestGenerateExpensesCSV(t *testing.T) {
 		require.Equal(t, "Uncategorized", records[1][6])
 	})
 
+	t.Run("treats empty category name as Uncategorized", func(t *testing.T) {
+		t.Parallel()
+		expenses := []models.Expense{
+			{
+				ID:          1,
+				Amount:      decimal.NewFromFloat(5.00),
+				Currency:    "SGD",
+				Description: "Misc",
+				CreatedAt:   time.Date(2026, 1, 15, 10, 30, 0, 0, time.UTC),
+				Category:    &models.Category{Name: ""}, // Non-nil but empty name
+			},
+		}
+
+		csvData, err := GenerateExpensesCSV(expenses)
+		require.NoError(t, err)
+
+		reader := csv.NewReader(strings.NewReader(string(csvData)))
+		records, err := reader.ReadAll()
+		require.NoError(t, err)
+		require.Equal(t, "Uncategorized", records[1][6],
+			"empty-name Category should fall back to Uncategorized, not an empty cell")
+	})
+
 	t.Run("handles empty expense list", func(t *testing.T) {
 		t.Parallel()
 		expenses := []models.Expense{}

--- a/internal/logger/privacy.go
+++ b/internal/logger/privacy.go
@@ -77,7 +77,9 @@ func SanitizeText(text string) string {
 
 	// For longer text, show prefix and length. Slice by rune so the prefix
 	// never splits a multi-byte character, and report the rune count so the
-	// "<N chars>" label matches its content.
+	// "<N chars>" label matches its content. Guard the slice length for
+	// inputs that are long in bytes but have fewer than 3 runes.
 	runes := []rune(text)
-	return fmt.Sprintf("%s...<%d chars>", string(runes[:3]), len(runes))
+	prefix := runes[:min(3, len(runes))]
+	return fmt.Sprintf("%s...<%d chars>", string(prefix), len(runes))
 }

--- a/internal/logger/privacy.go
+++ b/internal/logger/privacy.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"unicode/utf8"
 )
 
 var hashSalt string
@@ -71,9 +72,12 @@ func SanitizeText(text string) string {
 
 	// For short text, show first few characters
 	if len(text) <= 10 {
-		return fmt.Sprintf("<%d chars>", len(text))
+		return fmt.Sprintf("<%d chars>", utf8.RuneCountInString(text))
 	}
 
-	// For longer text, show prefix and length
-	return fmt.Sprintf("%s...<%d chars>", text[:3], len(text))
+	// For longer text, show prefix and length. Slice by rune so the prefix
+	// never splits a multi-byte character, and report the rune count so the
+	// "<N chars>" label matches its content.
+	runes := []rune(text)
+	return fmt.Sprintf("%s...<%d chars>", string(runes[:3]), len(runes))
 }

--- a/internal/logger/privacy_rapid_test.go
+++ b/internal/logger/privacy_rapid_test.go
@@ -1,6 +1,7 @@
 package logger
 
 import (
+	"strings"
 	"testing"
 	"unicode/utf8"
 
@@ -45,26 +46,14 @@ func TestHegelSanitizeTextPrefixIsRuneAligned(t *testing.T) {
 	hegel.Test(t, func(ht *hegel.T) {
 		in := hegel.Draw(ht, hegel.Text().MinSize(11))
 		out := SanitizeText(in)
-		// The long branch formats as "<3-byte prefix>...<N chars>". Locate the
-		// prefix between the start of the output and the "..." separator.
-		dotIdx := indexOf(out, "...")
-		if dotIdx < 0 {
+		// The long branch formats as "<3-rune prefix>...<N chars>". Split on
+		// the "..." separator to recover the prefix.
+		prefix, _, found := strings.Cut(out, "...")
+		if !found {
 			return // short-input branch took over; nothing to check here.
 		}
-		prefix := out[:dotIdx]
 		if !utf8.ValidString(prefix) {
 			ht.Fatalf("SanitizeText prefix splits a rune: input=%q prefix=%q", in, prefix)
 		}
 	})
-}
-
-// indexOf returns the byte index of the first occurrence of substr in s, or
-// -1 if absent.
-func indexOf(s, substr string) int {
-	for i := 0; i+len(substr) <= len(s); i++ {
-		if s[i:i+len(substr)] == substr {
-			return i
-		}
-	}
-	return -1
 }

--- a/internal/logger/privacy_rapid_test.go
+++ b/internal/logger/privacy_rapid_test.go
@@ -1,0 +1,70 @@
+package logger
+
+import (
+	"testing"
+	"unicode/utf8"
+
+	"hegel.dev/go/hegel"
+)
+
+// TestHegelSanitizeTextOutputIsValidUTF8 asserts that SanitizeText never
+// returns an invalid UTF-8 string for any input. A sanitizer that slices
+// the first three *bytes* of user text can split a multi-byte rune and
+// emit a dangling continuation byte, which violates this contract.
+func TestHegelSanitizeTextOutputIsValidUTF8(t *testing.T) {
+	t.Parallel()
+	hegel.Test(t, func(ht *hegel.T) {
+		in := hegel.Draw(ht, hegel.Text())
+		out := SanitizeText(in)
+		if !utf8.ValidString(out) {
+			ht.Fatalf("SanitizeText produced invalid UTF-8: input=%q output=%q", in, out)
+		}
+	})
+}
+
+// TestHegelSanitizeTextLongInputValidUTF8 focuses generation on inputs
+// longer than 10 bytes, where SanitizeText switches to its prefix-slicing
+// branch (the branch that can split a multi-byte rune).
+func TestHegelSanitizeTextLongInputValidUTF8(t *testing.T) {
+	t.Parallel()
+	hegel.Test(t, func(ht *hegel.T) {
+		in := hegel.Draw(ht, hegel.Text().MinSize(11))
+		out := SanitizeText(in)
+		if !utf8.ValidString(out) {
+			ht.Fatalf("SanitizeText produced invalid UTF-8: input=%q output=%q", in, out)
+		}
+	})
+}
+
+// TestHegelSanitizeTextPrefixIsRuneAligned asserts that, when the long-input
+// branch exposes a prefix, that prefix is a whole number of runes. This is
+// the sharper property behind the UTF-8 contract: the slice must not cut a
+// rune in half.
+func TestHegelSanitizeTextPrefixIsRuneAligned(t *testing.T) {
+	t.Parallel()
+	hegel.Test(t, func(ht *hegel.T) {
+		in := hegel.Draw(ht, hegel.Text().MinSize(11))
+		out := SanitizeText(in)
+		// The long branch formats as "<3-byte prefix>...<N chars>". Locate the
+		// prefix between the start of the output and the "..." separator.
+		dotIdx := indexOf(out, "...")
+		if dotIdx < 0 {
+			return // short-input branch took over; nothing to check here.
+		}
+		prefix := out[:dotIdx]
+		if !utf8.ValidString(prefix) {
+			ht.Fatalf("SanitizeText prefix splits a rune: input=%q prefix=%q", in, prefix)
+		}
+	})
+}
+
+// indexOf returns the byte index of the first occurrence of substr in s, or
+// -1 if absent.
+func indexOf(s, substr string) int {
+	for i := 0; i+len(substr) <= len(s); i++ {
+		if s[i:i+len(substr)] == substr {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/logger/privacy_rapid_test.go
+++ b/internal/logger/privacy_rapid_test.go
@@ -50,7 +50,10 @@ func TestHegelSanitizeTextPrefixIsRuneAligned(t *testing.T) {
 		// the "..." separator to recover the prefix.
 		prefix, _, found := strings.Cut(out, "...")
 		if !found {
-			return // short-input branch took over; nothing to check here.
+			// Defensive: MinSize(11) guarantees the long-text branch, so the
+			// "..." separator should always be present. This guard keeps the
+			// test correct if the size bound is ever relaxed.
+			return
 		}
 		if !utf8.ValidString(prefix) {
 			ht.Fatalf("SanitizeText prefix splits a rune: input=%q prefix=%q", in, prefix)

--- a/internal/logger/privacy_test.go
+++ b/internal/logger/privacy_test.go
@@ -88,6 +88,7 @@ func TestSanitizeDescription(t *testing.T) {
 }
 
 func TestSanitizeText(t *testing.T) {
+	t.Parallel()
 	t.Run("redacts empty text", func(t *testing.T) {
 		result := SanitizeText("")
 		require.Equal(t, "<empty>", result)
@@ -105,6 +106,7 @@ func TestSanitizeText(t *testing.T) {
 	})
 
 	t.Run("long multi-byte text produces valid UTF-8 prefix", func(t *testing.T) {
+		t.Parallel()
 		// "ab" + 3 Japanese chars = 2 + 9 = 11 bytes, 5 runes. The long-text
 		// branch must slice by rune so the prefix never splits a multi-byte
 		// character, and the "<N chars>" label must report the rune count.

--- a/internal/logger/privacy_test.go
+++ b/internal/logger/privacy_test.go
@@ -3,6 +3,7 @@ package logger
 import (
 	"os"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/require"
 )
@@ -101,6 +102,17 @@ func TestSanitizeText(t *testing.T) {
 		result := SanitizeText("this is a long text")
 		require.Contains(t, result, "thi...")
 		require.Contains(t, result, "19 chars")
+	})
+
+	t.Run("long multi-byte text produces valid UTF-8 prefix", func(t *testing.T) {
+		// "ab" + 3 Japanese chars = 2 + 9 = 11 bytes, 5 runes. The long-text
+		// branch must slice by rune so the prefix never splits a multi-byte
+		// character, and the "<N chars>" label must report the rune count.
+		result := SanitizeText("ab日本語") //nolint:gosmopolitan // Intentional Unicode coverage.
+		require.True(t, utf8.ValidString(result), "output must be valid UTF-8: %q", result)
+		require.Contains(t, result, "ab日...") //nolint:gosmopolitan // Intentional Unicode coverage.
+		require.Contains(t, result, "5 chars",
+			"<N chars> label must report rune count, not byte count")
 	})
 }
 


### PR DESCRIPTION
… Uncategorized

SanitizeText sliced its 3-rune prefix by byte, splitting multi-byte characters and emitting invalid UTF-8; the "<N chars>" label also reported byte count instead of rune count. aggregateByCategory and GenerateExpensesCSV only checked Category != nil, so a non-nil Category with an empty Name leaked through as "" instead of the "Uncategorized" sentinel used by habitCategoryName.

Found via Hegel property-based tests; added 7 Hegel PBTs and 3 deterministic regression tests. See docs/HEGEL_PBT_FINDINGS.md.

## Summary by Sourcery

Ensure UTF-8-safe text sanitization and consistently treat empty category names as "Uncategorized" across charting and CSV exports, with new property-based and regression tests documenting and guarding the fixes.

Bug Fixes:
- Prevent SanitizeText from producing invalid UTF-8 or misreporting character counts for multi-byte input.
- Treat expenses with empty category names as "Uncategorized" in both chart aggregation and CSV generation instead of emitting empty category keys or cells.

Enhancements:
- Align category handling in aggregation and CSV generation with the existing habitCategoryName behavior to provide a single, consistent notion of "Uncategorized" expenses.

Documentation:
- Document Hegel property-based testing findings and the three fixed bugs in HEGEL_PBT_FINDINGS.md.

Tests:
- Add Hegel property-based tests and focused unit tests for SanitizeText UTF-8 behavior and prefix alignment.
- Add Hegel property-based tests and deterministic tests to verify aggregateByCategory and GenerateExpensesCSV handle empty category names as "Uncategorized" and stay consistent with habitCategoryName.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed privacy text sanitization to be Unicode-safe by using character (rune) counts and rune-aligned truncation, preventing invalid UTF-8.
  * Fixed expense chart and CSV export categorization so empty category names are treated as **“Uncategorized”** (consistent across views).
* **Tests**
  * Added property-based regression tests to verify UTF-8 safety and consistent “Uncategorized” behavior across aggregation, CSV rendering, and categorization.
  * Updated unit tests for empty-category-name cases.
* **Documentation**
  * Added a findings document summarizing the detected issues, fixes, and the Hegel regression test command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->