### PR TITLE
Feature span enhancements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,7 @@ ENSURE that the test coverage stays at or above 50% (CI enforced).
 ## Committing
 
 - NEVER include Co-Authored-By field
-- ALWAYS run both unit and integraton tests before pushing
+- ALWAYS run both unit and integration tests before pushing
     - Especially, the fail tests with `mise test-integration 2&>1 | grep -w 'FAIL:'`
 - ALWAYS use semantic commits (`fix:`, `feat:`, `chore:`, `refactor:`, `docs:`, `sec:`, etc).
 - ALWAYS run pre-commits before pushing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,7 @@ ENSURE that the test coverage stays at or above 50% (CI enforced).
 
 ## Committing
 
-- NEVER include Co-Author field
+- NEVER include Co-Authored-By field
 - ALWAYS run both unit and integraton tests before pushing
     - Especially, the fail tests with `mise test-integration 2&>1 | grep -w 'FAIL:'`
 - ALWAYS use semantic commits (`fix:`, `feat:`, `chore:`, `refactor:`, `docs:`, `sec:`, etc).

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -93,6 +93,12 @@ func New(ctx context.Context, cfg *config.Config, db database.PGXDB) (*Bot, erro
 		bot.WithMiddlewares(middlewares...),
 		bot.WithDefaultHandler(b.defaultHandler),
 	}
+	if cfg.OTelEnabled {
+		// Instrument the bot library's HTTP client so every Telegram API call
+		// (sends, edits, getFile) emits a client span. telegramPollTimeout
+		// matches the library default so long-poll behavior is unchanged.
+		opts = append(opts, bot.WithHTTPClient(telegramPollTimeout, telemetry.TelegramHTTPClient(telegramPollTimeout)))
+	}
 
 	telegramBot, err := bot.New(cfg.TelegramBotToken, opts...)
 	if err != nil {
@@ -221,6 +227,9 @@ const (
 	DraftCleanupInterval = 5 * time.Minute
 	// CategoryCacheTTL is how long category cache remains valid.
 	CategoryCacheTTL = 5 * time.Minute
+	// telegramPollTimeout matches the go-telegram bot library default poll
+	// timeout; passed to WithHTTPClient so long-poll behavior is unchanged.
+	telegramPollTimeout = time.Minute
 )
 
 // Start begins polling for updates.

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -20,7 +20,9 @@ import (
 	"gitlab.com/yelinaung/expense-bot/internal/models"
 	"gitlab.com/yelinaung/expense-bot/internal/repository"
 	"gitlab.com/yelinaung/expense-bot/internal/telemetry"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	otelmetric "go.opentelemetry.io/otel/metric"
 )
 
@@ -292,9 +294,13 @@ func (b *Bot) draftExpiration() time.Duration {
 
 // cleanupExpiredDrafts removes draft expenses older than the configured retention.
 func (b *Bot) cleanupExpiredDrafts(ctx context.Context) {
+	ctx, span := otel.Tracer("expense-bot/background").Start(ctx, "background.draft_cleanup")
+	defer span.End()
 	start := time.Now()
 	count, err := b.expenseRepo.DeleteExpiredDrafts(ctx, b.draftExpiration())
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		logger.Log.Error().Err(err).Msg("Failed to cleanup expired drafts")
 		if b.metrics != nil {
 			b.metrics.BackgroundJobRuns.Add(ctx, 1, otelmetric.WithAttributes(attribute.String("job", "draft_cleanup"), attribute.String("status", "error")))
@@ -302,6 +308,7 @@ func (b *Bot) cleanupExpiredDrafts(ctx context.Context) {
 		}
 		return
 	}
+	span.SetAttributes(attribute.Int("drafts_cleaned", count))
 	if count > 0 {
 		logger.Log.Info().Int("count", count).Msg("Cleaned up expired draft expenses")
 		if b.metrics != nil {

--- a/internal/bot/handlers_chart.go
+++ b/internal/bot/handlers_chart.go
@@ -10,6 +10,9 @@ import (
 	"github.com/go-telegram/bot"
 	"github.com/go-telegram/bot/models"
 	"gitlab.com/yelinaung/expense-bot/internal/logger"
+	"gitlab.com/yelinaung/expense-bot/internal/telemetry"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 )
 
 const (
@@ -96,8 +99,15 @@ func (b *Bot) handleChartCore(ctx context.Context, tg TelegramAPI, update *model
 	}
 
 	// Generate chart
+	_, genSpan := telemetry.StartSpan(ctx, "chart.generate",
+		attribute.String("chart.period", period),
+		attribute.Int("chart.expense_count", len(expenses)),
+	)
 	chartData, err := GenerateExpenseChart(expenses, period)
 	if err != nil {
+		genSpan.RecordError(err)
+		genSpan.SetStatus(codes.Error, "chart generation failed")
+		genSpan.End()
 		logger.Log.Error().Err(err).Msg("Failed to generate chart")
 		_, _ = tg.SendMessage(ctx, &bot.SendMessageParams{
 			ChatID: chatID,
@@ -105,6 +115,8 @@ func (b *Bot) handleChartCore(ctx context.Context, tg TelegramAPI, update *model
 		})
 		return
 	}
+	genSpan.SetAttributes(attribute.Int("chart.size_bytes", len(chartData)))
+	genSpan.End()
 
 	total, err := b.expenseRepo.GetTotalByUserIDAndDateRange(ctx, userID, startDate, endDate)
 	if err != nil {
@@ -130,13 +142,20 @@ func (b *Bot) handleChartCore(ctx context.Context, tg TelegramAPI, update *model
 	caption := fmt.Sprintf("📊 <b>%s</b>\n\nTotal: $%s SGD\nCount: %d expenses\nPeriod: %s",
 		title, total.StringFixed(2), len(expenses), periodRange)
 
-	_, err = tg.SendDocument(ctx, &bot.SendDocumentParams{
+	sendCtx, sendSpan := telemetry.StartSpan(ctx, "telegram.send_document",
+		attribute.Int("document.size_bytes", len(chartData)),
+		attribute.String("document.filename", filename),
+	)
+	_, err = tg.SendDocument(sendCtx, &bot.SendDocumentParams{
 		ChatID:    chatID,
 		Document:  &models.InputFileUpload{Filename: filename, Data: bytes.NewReader(chartData)},
 		Caption:   caption,
 		ParseMode: models.ParseModeHTML,
 	})
 	if err != nil {
+		sendSpan.RecordError(err)
+		sendSpan.SetStatus(codes.Error, "send document failed")
+		sendSpan.End()
 		logger.Log.Error().Err(err).Msg("Failed to send chart document")
 		_, _ = tg.SendMessage(ctx, &bot.SendMessageParams{
 			ChatID: chatID,
@@ -144,6 +163,7 @@ func (b *Bot) handleChartCore(ctx context.Context, tg TelegramAPI, update *model
 		})
 		return
 	}
+	sendSpan.End()
 
 	logger.Log.Info().
 		Int64("user_id", userID).

--- a/internal/bot/handlers_chart_test.go
+++ b/internal/bot/handlers_chart_test.go
@@ -2,6 +2,7 @@ package bot
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -122,6 +123,19 @@ func TestHandleChartCore(t *testing.T) {
 		require.Contains(t, doc.Caption, "Total:")
 		require.Contains(t, doc.Caption, "Count:")
 		require.Contains(t, doc.Caption, fmt.Sprintf("%d expenses", totalMonthlyExpenseCount))
+	})
+
+	t.Run("sends failure message when document send fails", func(t *testing.T) {
+		mockBot := mocks.NewMockBot()
+		mockBot.SendDocumentError = errors.New("telegram send failed")
+		update := mocks.CommandUpdate(chatID, userID, testChartWeekCommand)
+
+		b.handleChartCore(ctx, mockBot, update)
+
+		// SendDocument failed, so the handler falls back to an error message.
+		msg := mockBot.LastSentMessage()
+		require.NotNil(t, msg)
+		require.Contains(t, msg.Text, "❌ Failed to send chart")
 	})
 
 	t.Run("returns error for invalid period", func(t *testing.T) {

--- a/internal/telemetry/httpclient.go
+++ b/internal/telemetry/httpclient.go
@@ -50,7 +50,7 @@ func (t telegramTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 		return t.base.RoundTrip(req)
 	}
 
-	_, span := tracer.Start(req.Context(), "telegram.api "+method,
+	ctx, span := tracer.Start(req.Context(), "telegram.api "+method,
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
 			attribute.String("rpc.system", "telegram"),
@@ -58,6 +58,10 @@ func (t telegramTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 		),
 	)
 	defer span.End()
+
+	// Attach the span context so the base transport (and any further
+	// instrumentation) observes the in-flight span.
+	req = req.WithContext(ctx)
 
 	resp, err := t.base.RoundTrip(req)
 	if err != nil {
@@ -72,17 +76,29 @@ func (t telegramTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 	return resp, nil
 }
 
-// telegramMethod extracts the Telegram API method (the trailing path segment)
-// from a request URL path of the form /bot<token>/<method>. The token is in a
-// separate segment and is never returned.
+const (
+	unknownTelegramMethod = "unknown"
+	telegramBotPrefix     = "/bot"
+)
+
+// telegramMethod extracts the Telegram API method from a request URL path of
+// the form /bot<token>/<method>. It returns the method only when a non-empty
+// segment follows the bot token; for a root or malformed path such as
+// "/bot<token>" it returns unknownTelegramMethod so the token (which is part of
+// the path) is never exposed in span names or attributes.
 func telegramMethod(path string) string {
-	if idx := strings.LastIndex(path, "/"); idx >= 0 {
-		path = path[idx+1:]
-	}
-	if path == "" {
+	if !strings.HasPrefix(path, telegramBotPrefix) {
 		return unknownTelegramMethod
 	}
-	return path
+	// rest is "<token>[/...]/<method>"; a '/' must separate the token from a
+	// method segment, otherwise the trailing segment is the token itself.
+	rest := path[len(telegramBotPrefix):]
+	if !strings.Contains(rest, "/") {
+		return unknownTelegramMethod
+	}
+	method := rest[strings.LastIndexByte(rest, '/')+1:]
+	if method == "" {
+		return unknownTelegramMethod
+	}
+	return method
 }
-
-const unknownTelegramMethod = "unknown"

--- a/internal/telemetry/httpclient.go
+++ b/internal/telemetry/httpclient.go
@@ -2,8 +2,13 @@ package telemetry
 
 import (
 	"net/http"
+	"strings"
+	"time"
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // InstrumentedTransport wraps the given http.RoundTripper (or
@@ -14,3 +19,70 @@ func InstrumentedTransport(base http.RoundTripper) http.RoundTripper {
 	}
 	return otelhttp.NewTransport(base)
 }
+
+// TelegramHTTPClient returns an *http.Client for the go-telegram bot library
+// that emits a client span per Telegram API call, named after the method
+// (e.g. "telegram.api sendMessage"). pollTimeout must match the bot's poll
+// timeout so the long-poll getUpdates request is not cut short.
+//
+// It deliberately does NOT use otelhttp: that instrumentation records the full
+// request URL, and the Telegram endpoint embeds the bot token in the path
+// (/bot<token>/<method>), which would leak the secret into span attributes.
+// This transport records only the method name and response status.
+func TelegramHTTPClient(pollTimeout time.Duration) *http.Client {
+	return &http.Client{
+		Timeout:   pollTimeout,
+		Transport: telegramTransport{base: http.DefaultTransport},
+	}
+}
+
+type telegramTransport struct {
+	base http.RoundTripper
+}
+
+func (t telegramTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	method := telegramMethod(req.URL.Path)
+
+	// Skip the long-poll getUpdates request: it is held open for the poll
+	// timeout and runs outside any handler span, so instrumenting it would
+	// emit a continuous stream of parentless, ~pollTimeout-long spans.
+	if method == "getUpdates" {
+		return t.base.RoundTrip(req)
+	}
+
+	_, span := tracer.Start(req.Context(), "telegram.api "+method,
+		trace.WithSpanKind(trace.SpanKindClient),
+		trace.WithAttributes(
+			attribute.String("rpc.system", "telegram"),
+			attribute.String("telegram.method", method),
+		),
+	)
+	defer span.End()
+
+	resp, err := t.base.RoundTrip(req)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return resp, err
+	}
+	span.SetAttributes(attribute.Int("http.response.status_code", resp.StatusCode))
+	if resp.StatusCode >= http.StatusBadRequest {
+		span.SetStatus(codes.Error, resp.Status)
+	}
+	return resp, nil
+}
+
+// telegramMethod extracts the Telegram API method (the trailing path segment)
+// from a request URL path of the form /bot<token>/<method>. The token is in a
+// separate segment and is never returned.
+func telegramMethod(path string) string {
+	if idx := strings.LastIndex(path, "/"); idx >= 0 {
+		path = path[idx+1:]
+	}
+	if path == "" {
+		return unknownTelegramMethod
+	}
+	return path
+}
+
+const unknownTelegramMethod = "unknown"

--- a/internal/telemetry/span.go
+++ b/internal/telemetry/span.go
@@ -1,0 +1,16 @@
+package telemetry
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// StartSpan starts a child span on the bot tracer with the given attributes.
+// When OTel is disabled the global no-op tracer is used, so this is safe and
+// cheap to call unconditionally. The caller must End the returned span.
+func StartSpan(ctx context.Context, name string, attrs ...attribute.KeyValue) (context.Context, trace.Span) {
+	//nolint:spancheck // span is intentionally returned for the caller to End.
+	return tracer.Start(ctx, name, trace.WithAttributes(attrs...))
+}

--- a/internal/telemetry/telegram_transport_test.go
+++ b/internal/telemetry/telegram_transport_test.go
@@ -1,0 +1,79 @@
+package telemetry
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTelegramMethod(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{"send message", "/bot12345:secret/sendMessage", "sendMessage"},
+		{"get updates", "/bot12345:secret/getUpdates", "getUpdates"},
+		{"get file", "/bot12345:secret/getFile", "getFile"},
+		{"empty trailing", "/bot12345:secret/", "unknown"},
+		{"no slash", "", "unknown"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, telegramMethod(tt.path))
+		})
+	}
+}
+
+func okResponse() *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(http.NoBody),
+		Header:     make(http.Header),
+	}
+}
+
+// roundTripForMethod sends a request for the given Telegram method through the
+// transport and returns the method the base transport actually saw.
+func roundTripForMethod(t *testing.T, method string) string {
+	t.Helper()
+	var gotMethod string
+	base := roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		gotMethod = telegramMethod(r.URL.Path)
+		return okResponse(), nil
+	})
+	tr := telegramTransport{base: base}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		"https://api.telegram.org/bot12345:secret/"+method, nil)
+	require.NoError(t, err)
+	resp, err := tr.RoundTrip(req)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	return gotMethod
+}
+
+func TestTelegramTransport_SkipsGetUpdates(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "getUpdates", roundTripForMethod(t, "getUpdates"))
+}
+
+func TestTelegramTransport_TracesSendMessage(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "sendMessage", roundTripForMethod(t, "sendMessage"))
+}
+
+func TestTelegramHTTPClient(t *testing.T) {
+	t.Parallel()
+
+	c := TelegramHTTPClient(time.Minute)
+	require.NotNil(t, c)
+	require.Equal(t, time.Minute, c.Timeout)
+	require.IsType(t, telegramTransport{}, c.Transport)
+}

--- a/internal/telemetry/telegram_transport_test.go
+++ b/internal/telemetry/telegram_transport_test.go
@@ -8,6 +8,10 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
 )
 
 func TestTelegramMethod(t *testing.T) {
@@ -21,7 +25,10 @@ func TestTelegramMethod(t *testing.T) {
 		{"send message", "/bot12345:secret/sendMessage", "sendMessage"},
 		{"get updates", "/bot12345:secret/getUpdates", "getUpdates"},
 		{"get file", "/bot12345:secret/getFile", "getFile"},
+		{"test environment", "/bot12345:secret/test/sendMessage", "sendMessage"},
 		{"empty trailing", "/bot12345:secret/", "unknown"},
+		{"root bot path leaks no token", "/bot12345:secret", "unknown"},
+		{"no bot prefix", "/foo/sendMessage", "unknown"},
 		{"no slash", "", "unknown"},
 	}
 	for _, tt := range tests {
@@ -40,33 +47,66 @@ func okResponse() *http.Response {
 	}
 }
 
-// roundTripForMethod sends a request for the given Telegram method through the
-// transport and returns the method the base transport actually saw.
-func roundTripForMethod(t *testing.T, method string) string {
+// telegramTestURL is a fake Telegram endpoint whose token segment is used to
+// assert the secret never leaks into span attributes.
+const (
+	telegramTestToken = "12345:secret"
+	telegramTestURL   = "https://api.telegram.org/bot" + telegramTestToken + "/"
+)
+
+// roundTrip runs a request for the given Telegram method through tr and closes
+// the response body.
+func roundTrip(t *testing.T, tr telegramTransport, method string) {
 	t.Helper()
-	var gotMethod string
-	base := roundTripperFunc(func(r *http.Request) (*http.Response, error) {
-		gotMethod = telegramMethod(r.URL.Path)
-		return okResponse(), nil
-	})
-	tr := telegramTransport{base: base}
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost,
-		"https://api.telegram.org/bot12345:secret/"+method, nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, telegramTestURL+method, nil)
 	require.NoError(t, err)
 	resp, err := tr.RoundTrip(req)
 	require.NoError(t, err)
 	require.NoError(t, resp.Body.Close())
-	return gotMethod
 }
 
-func TestTelegramTransport_SkipsGetUpdates(t *testing.T) {
-	t.Parallel()
-	require.Equal(t, "getUpdates", roundTripForMethod(t, "getUpdates"))
-}
+// TestTelegramTransport_SpanBehavior installs an in-memory tracer provider and
+// asserts the transport's span behavior. It is intentionally not parallel: it
+// mutates the global tracer provider that the package-level tracer delegates to.
+func TestTelegramTransport_SpanBehavior(t *testing.T) {
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() { otel.SetTracerProvider(prev) })
 
-func TestTelegramTransport_TracesSendMessage(t *testing.T) {
-	t.Parallel()
-	require.Equal(t, "sendMessage", roundTripForMethod(t, "sendMessage"))
+	base := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		return okResponse(), nil
+	})
+	tr := telegramTransport{base: base}
+
+	t.Run("sendMessage creates a client span without leaking the token", func(t *testing.T) {
+		sr.Reset()
+		roundTrip(t, tr, "sendMessage")
+
+		spans := sr.Ended()
+		require.Len(t, spans, 1)
+		span := spans[0]
+		require.Equal(t, "telegram.api sendMessage", span.Name())
+		require.Equal(t, trace.SpanKindClient, span.SpanKind())
+
+		attrs := make(map[string]string)
+		for _, kv := range span.Attributes() {
+			attrs[string(kv.Key)] = kv.Value.String()
+			// The bot token must never appear in any span attribute value.
+			require.NotContains(t, kv.Value.String(), "secret")
+			require.NotContains(t, kv.Value.String(), "12345")
+		}
+		require.Equal(t, "telegram", attrs["rpc.system"])
+		require.Equal(t, "sendMessage", attrs["telegram.method"])
+		require.Equal(t, "200", attrs["http.response.status_code"])
+	})
+
+	t.Run("getUpdates creates no span", func(t *testing.T) {
+		sr.Reset()
+		roundTrip(t, tr, "getUpdates")
+		require.Empty(t, sr.Ended())
+	})
 }
 
 func TestTelegramHTTPClient(t *testing.T) {

--- a/internal/telemetry/telegram_transport_test.go
+++ b/internal/telemetry/telegram_transport_test.go
@@ -2,6 +2,7 @@ package telemetry
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"testing"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/codes"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
@@ -106,6 +108,41 @@ func TestTelegramTransport_SpanBehavior(t *testing.T) {
 		sr.Reset()
 		roundTrip(t, tr, "getUpdates")
 		require.Empty(t, sr.Ended())
+	})
+
+	t.Run("non-2xx status marks the span as error", func(t *testing.T) {
+		sr.Reset()
+		errTr := telegramTransport{base: roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusBadRequest,
+				Status:     "400 Bad Request",
+				Body:       io.NopCloser(http.NoBody),
+				Header:     make(http.Header),
+			}, nil
+		})}
+		roundTrip(t, errTr, "sendMessage")
+
+		spans := sr.Ended()
+		require.Len(t, spans, 1)
+		require.Equal(t, codes.Error, spans[0].Status().Code)
+	})
+
+	t.Run("transport error is recorded on the span", func(t *testing.T) {
+		sr.Reset()
+		wantErr := errors.New("dial failed")
+		errTr := telegramTransport{base: roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+			return nil, wantErr
+		})}
+
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, telegramTestURL+"sendMessage", nil)
+		require.NoError(t, err)
+		resp, err := errTr.RoundTrip(req)
+		require.ErrorIs(t, err, wantErr)
+		require.Nil(t, resp)
+
+		spans := sr.Ended()
+		require.Len(t, spans, 1)
+		require.Equal(t, codes.Error, spans[0].Status().Code)
 	})
 }
 


### PR DESCRIPTION
## Summary by Sourcery

Add OpenTelemetry tracing for Telegram bot HTTP calls, chart generation, and background draft cleanup while ensuring Telegram tokens are not exposed in spans.

New Features:
- Provide a custom Telegram HTTP client that emits sanitized client spans per Telegram API call without leaking the bot token.
- Add helper to start spans on the shared bot tracer for consistent telemetry usage.

Enhancements:
- Instrument chart generation and Telegram document sending with detailed telemetry attributes and error reporting.
- Instrument background draft cleanup with tracing, including counts and error status.
- Align Telegram bot HTTP client configuration with library poll timeout defaults for transparent long polling behavior.

Documentation:
- Clarify contributing guidance about excluding the Co-Authored-By field in commit messages.

Tests:
- Add unit tests covering Telegram HTTP client transport behavior and Telegram API method extraction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved app monitoring and request tracing for better reliability and faster issue diagnosis.
  * Added more detailed tracking around chart generation and delivery, including cleaner error handling when sending fails.

* **Documentation**
  * Updated commit guidance wording in contributor instructions.

* **Tests**
  * Added coverage for Telegram request handling and tracing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->