### PR TITLE
ci: self-built OTel exporter with correlated job logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -373,8 +373,10 @@ jobs:
     if: always()
     name: OpenTelemetry Export (traces + logs)
     runs-on: [self-hosted, Linux, X64, playground-ubuntu]
-    # Never fail the workflow on a telemetry-export hiccup.
+    # Never fail the workflow on a telemetry-export hiccup, and time-bound it so
+    # a hung download/API/POST can't keep the job running to the default limit.
     continue-on-error: true
+    timeout-minutes: 10
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,10 +369,12 @@ jobs:
       - name: Run govulncheck
         run: govulncheck ./...
 
-  otel-cicd-action:
+  otel-export:
     if: always()
-    name: OpenTelemetry Export Trace
+    name: OpenTelemetry Export (traces + logs)
     runs-on: [self-hosted, Linux, X64, playground-ubuntu]
+    # Never fail the workflow on a telemetry-export hiccup.
+    continue-on-error: true
     permissions:
       contents: read
       actions: read
@@ -388,10 +390,32 @@ jobs:
         dependency-review,
         govulncheck,
       ]
+    env:
+      # renovate: datasource=github-releases depName=equinix-labs/otel-cli
+      OTEL_CLI_VERSION: "0.4.5"
+      OTEL_EXPORTER_OTLP_ENDPOINT: ${{ vars.OTEL_EXPORTER_OTLP_ENDPOINT }}
+      OTEL_EXPORTER_OTLP_HEADERS: ${{ secrets.OTEL_EXPORTER_HEADERS }}
+      OTEL_EXPORTER_OTLP_PROTOCOL: http/protobuf
+      OTEL_ENDPOINT_HOST_IP: ${{ vars.OTEL_ENDPOINT_HOST_IP }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - name: Export workflow
-        uses: corentinmusard/otel-cicd-action@f2d88ecf54d9dd3e01ea95e25f93603212ee93d3 # v4
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
-          otlpEndpoint: ${{ vars.OTEL_EXPORTER_OTLP_ENDPOINT }}/v1/traces
-          otlpHeaders: ${{ secrets.OTEL_EXPORTER_HEADERS }}
-          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          egress-policy: audit
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Check OTLP endpoint is configured
+        id: guard
+        run: |
+          if [ -z "${OTEL_EXPORTER_OTLP_ENDPOINT}" ]; then
+            echo "OTEL_EXPORTER_OTLP_ENDPOINT not set; skipping export."
+            echo "skip=true" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Export workflow trace + logs
+        if: steps.guard.outputs.skip != 'true'
+        run: sh scripts/ci/export-otel-github.sh

--- a/renovate.json
+++ b/renovate.json
@@ -27,7 +27,7 @@
         "digest"
       ],
       "schedule": ["on sunday"],
-      "minimumReleaseAge": "0 days",
+      "minimumReleaseAge": false,
       "automerge": true,
       "platformAutomerge": true
     },

--- a/scripts/ci/export-otel-github.sh
+++ b/scripts/ci/export-otel-github.sh
@@ -197,20 +197,23 @@ while IFS="$(printf '\t')" read -r name status started finished id; do
     cancelled|timed_out|action_required) sev_text=WARN; sev_num=13 ;;
     *)                              sev_text=INFO;  sev_num=9  ;;
   esac
-  set +e
-  if gh_api "${API}/repos/${GITHUB_REPOSITORY}/actions/jobs/${id}/logs" -o job.log; then
+  # Each fallible step is guarded individually with `if` so errexit stays on
+  # for the rest of the loop: a genuine bug still aborts, but a per-job log
+  # fetch/build/upload failure just warns and moves on.
+  if ! gh_api "${API}/repos/${GITHUB_REPOSITORY}/actions/jobs/${id}/logs" -o job.log; then
+    echo "    WARNING: could not fetch logs for job ${id}"
+  elif [ -s job.log ]; then
     nanos=$(jq -rn --arg ts "${finished}" \
       '($ts[0:19] + "Z" | fromdateiso8601 | tostring) + "000000000"')
-    if [ -s job.log ]; then
-      # Normalize CRLF -> LF so the body carries clean \n line breaks, then
-      # emit compact JSON (-c) so the payload's only real newlines are the
-      # in-string \n escapes.
-      tr -d '\r' < job.log | tail -n "${MAX_LINES}" | jq -R -s -c \
+    # Normalize CRLF -> LF so the body carries clean \n line breaks, then emit
+    # compact JSON (-c) so the payload's only real newlines are the in-string
+    # \n escapes. A failed build skips the upload rather than sending garbage.
+    if tr -d '\r' < job.log | tail -n "${MAX_LINES}" | jq -R -s -c \
         --arg trace "${TRACE_ID}" --arg span "${SPAN_ID}" \
         --arg jobname "${name}" --arg jobid "${id}" --arg jobstatus "${status}" \
         --arg service "${SERVICE_NAME}" --arg nanos "${nanos}" \
         --arg severity "${sev_text}" --arg sevnum "${sev_num}" \
-        "${LOGS_JQ}" > logs-payload.json
+        "${LOGS_JQ}" > logs-payload.json; then
       # --data-binary (not --data): --data strips newlines from file input,
       # which would concatenate the log lines; --data-binary sends bytes as-is.
       if curl -sS --fail -K "${HDR_CONF}" \
@@ -220,10 +223,9 @@ while IFS="$(printf '\t')" read -r name status started finished id; do
       else
         echo "    WARNING: log export failed for job ${id}"
       fi
+    else
+      echo "    WARNING: could not build log payload for job ${id}"
     fi
-  else
-    echo "    WARNING: could not fetch logs for job ${id}"
   fi
-  set -e
 done
 echo "Trace + log export complete."

--- a/scripts/ci/export-otel-github.sh
+++ b/scripts/ci/export-otel-github.sh
@@ -1,0 +1,194 @@
+#!/bin/sh
+# Export the whole GitHub Actions run as an OpenTelemetry trace AND its job
+# logs to ClickStack. One root span for the run plus a child span per job
+# (built from the GitHub Actions API with otel-cli), and every job's log lines
+# shipped as OTLP log records stamped with the same trace id + that job's span
+# id, so logs and spans correlate in the backend.
+#
+# This is the self-built counterpart to corentinmusard/otel-cicd-action: the
+# action only emits traces and hides the span ids it mints, which makes
+# log<->span correlation impossible. Here we force our own ids (mirroring
+# scripts/ci/export-otel-trace.sh on GitLab) so we can attach correlated logs.
+#
+# POSIX sh. Expects in the environment:
+#   OTEL_CLI_VERSION              pinned otel-cli release
+#   OTEL_EXPORTER_OTLP_ENDPOINT   collector base URL (we append /v1/traces, /v1/logs)
+#   OTEL_EXPORTER_OTLP_PROTOCOL   http/protobuf
+#   OTEL_EXPORTER_OTLP_HEADERS    ingestion auth header(s), e.g. authorization=<key>
+#   OTEL_ENDPOINT_HOST_IP         (optional) IP to map the endpoint host to in /etc/hosts
+#   OTEL_LOG_MAX_LINES            (optional) per-job log line cap, default 2000
+#   GITHUB_TOKEN                  token with actions:read for the jobs + logs API
+#   GITHUB_* predefined Actions variables
+set -eu
+
+: "${OTEL_EXPORTER_OTLP_ENDPOINT:?OTEL_EXPORTER_OTLP_ENDPOINT not set}"
+: "${GITHUB_TOKEN:?GITHUB_TOKEN not set}"
+BASE=${OTEL_EXPORTER_OTLP_ENDPOINT%/}
+MAX_LINES=${OTEL_LOG_MAX_LINES:-2000}
+API=${GITHUB_API_URL:-https://api.github.com}
+ATTEMPT=${GITHUB_RUN_ATTEMPT:-1}
+
+command -v curl >/dev/null 2>&1 || { echo "curl not found"; exit 1; }
+command -v jq   >/dev/null 2>&1 || { echo "jq not found"; exit 1; }
+
+# --- install otel-cli into a local dir (pinned + checksum-verified) ---
+# Local dir avoids needing root/sudo on the self-hosted runner.
+echo "Installing otel-cli v${OTEL_CLI_VERSION}..."
+BIN_DIR=$(mktemp -d)
+GH="https://github.com/equinix-labs/otel-cli/releases/download/v${OTEL_CLI_VERSION}"
+TARBALL="otel-cli_${OTEL_CLI_VERSION}_linux_amd64.tar.gz"
+curl --proto "=https" -sSfL -o "${BIN_DIR}/${TARBALL}" "${GH}/${TARBALL}"
+curl --proto "=https" -sSfL -o "${BIN_DIR}/checksums.txt" "${GH}/checksums.txt"
+( cd "${BIN_DIR}" && grep " ${TARBALL}\$" checksums.txt | sha256sum -c - )
+tar -xzf "${BIN_DIR}/${TARBALL}" -C "${BIN_DIR}" otel-cli
+OTEL_CLI="${BIN_DIR}/otel-cli"
+
+# otel-cli defaults to gRPC; force HTTP and surface export failures.
+OTEL_ARGS="--protocol http/protobuf --endpoint ${OTEL_EXPORTER_OTLP_ENDPOINT} --fail --verbose"
+echo "Endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT} (traces -> /v1/traces, logs -> /v1/logs)"
+
+# The runner may resolve via LAN DNS and be unable to resolve the Tailscale
+# MagicDNS name. Optionally map the hostname to a reachable IP (best-effort;
+# needs write access to /etc/hosts, so try sudo and never fail the job).
+OTEL_HOST=${OTEL_EXPORTER_OTLP_ENDPOINT#*://}
+OTEL_HOST=${OTEL_HOST%%/*}
+OTEL_HOST=${OTEL_HOST%%:*}
+if [ -n "${OTEL_ENDPOINT_HOST_IP:-}" ]; then
+  if echo "${OTEL_ENDPOINT_HOST_IP} ${OTEL_HOST}" >> /etc/hosts 2>/dev/null; then
+    echo "Mapped ${OTEL_HOST} -> ${OTEL_ENDPOINT_HOST_IP} via /etc/hosts"
+  elif command -v sudo >/dev/null 2>&1 &&
+       echo "${OTEL_ENDPOINT_HOST_IP} ${OTEL_HOST}" | sudo -n tee -a /etc/hosts >/dev/null 2>&1; then
+    echo "Mapped ${OTEL_HOST} -> ${OTEL_ENDPOINT_HOST_IP} via /etc/hosts (sudo)"
+  else
+    echo "WARNING: could not write /etc/hosts; relying on DNS for ${OTEL_HOST}"
+  fi
+fi
+
+# --- curl config with OTLP auth headers (for our raw /v1/logs POSTs) ---
+# Written as a curl -K config file to sidestep quoting/word-splitting.
+# Split the comma-separated header list via parameter expansion instead of
+# tampering with IFS globally.
+HDR_CONF="${BIN_DIR}/otlp-headers.conf"
+: > "${HDR_CONF}"
+headers=${OTEL_EXPORTER_OTLP_HEADERS:-}
+while [ -n "${headers}" ]; do
+  case "${headers}" in
+    *,*) pair=${headers%%,*}; headers=${headers#*,} ;;
+    *)   pair=${headers};     headers= ;;
+  esac
+  [ -n "${pair}" ] || continue
+  key=${pair%%=*}
+  val=${pair#*=}
+  printf 'header = "%s: %s"\n' "${key}" "${val}" >> "${HDR_CONF}"
+done
+
+# --- fetch this run's jobs from the GitHub API ---
+gh_api() {
+  curl -sSfL \
+    -H "Accept: application/vnd.github+json" \
+    -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "$@"
+}
+gh_api "${API}/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${ATTEMPT}/jobs?per_page=100" \
+  > jobs.json
+echo "Jobs fetched: $(jq '.jobs | length' jobs.json), completed: $(jq '[.jobs[]|select(.completed_at!=null)]|length' jobs.json)"
+
+# --- run span boundaries from job timestamps ---
+RUN_START=$(jq -r '[.jobs[].started_at   | select(. != null)] | min // empty' jobs.json)
+RUN_END=$(jq   -r '[.jobs[].completed_at | select(. != null)] | max // empty' jobs.json)
+: "${RUN_START:?no started jobs found - nothing to export}"
+: "${RUN_END:=$RUN_START}"
+echo "Run window: ${RUN_START} -> ${RUN_END}"
+
+# --- generate our own trace/span ids so children + logs link deterministically
+# (W3C: 16-byte trace id, 8-byte span id, as hex). ---
+TRACE_ID=$(head -c 16 /dev/urandom | od -An -tx1 | tr -d ' \n')
+ROOT_SPAN_ID=$(head -c 8 /dev/urandom | od -An -tx1 | tr -d ' \n')
+SERVICE_NAME="github-ci/${GITHUB_REPOSITORY}"
+echo "Trace ID: ${TRACE_ID}  Service: ${SERVICE_NAME}"
+
+# --- root span for the run ---
+# shellcheck disable=SC2086
+"${OTEL_CLI}" span ${OTEL_ARGS} \
+  --service "${SERVICE_NAME}" \
+  --name "run #${GITHUB_RUN_ID} (${GITHUB_REF_NAME:-})" \
+  --start "${RUN_START}" --end "${RUN_END}" \
+  --attrs "ci.run.id=${GITHUB_RUN_ID},ci.run.attempt=${ATTEMPT},ci.repo=${GITHUB_REPOSITORY},ci.commit.ref=${GITHUB_REF_NAME:-},ci.commit.sha=${GITHUB_SHA:-}" \
+  --force-trace-id "${TRACE_ID}" --force-span-id "${ROOT_SPAN_ID}"
+echo "Root span sent."
+
+# jq program: turn a plaintext GitHub job log into an OTLP/HTTP JSON logs
+# payload, one log record per line, each carrying trace_id + this job's span_id.
+# GitHub prefixes every line with an RFC3339 timestamp we reuse for the record.
+# $trace/$span/etc. are jq variables, not shell — single quotes are correct.
+# shellcheck disable=SC2016
+LOGS_JQ='
+def nanos($ts):
+  ($ts[0:19] + "Z" | fromdateiso8601 | tostring)
+  + ((( ($ts | capture("\\.(?<f>[0-9]+)Z$") | .f) // "") + "000000000")[0:9]);
+def parse($line):
+  if ($line | test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.]+Z "))
+  then ($line | capture("^(?<ts>\\S+) (?<msg>.*)$"))
+  else {ts: null, msg: $line} end;
+def sev($msg):
+  if   ($msg | test("##\\[error\\]"))   then {t:"ERROR", n:17}
+  elif ($msg | test("##\\[warning\\]")) then {t:"WARN",  n:13}
+  else {t:"INFO", n:9} end;
+split("\n")
+| map(select(length > 0))
+| map(parse(.) as $p | sev($p.msg) as $s
+    | { timeUnixNano: (if $p.ts then nanos($p.ts) else $defaultNanos end),
+        severityText: $s.t, severityNumber: $s.n,
+        body: { stringValue: $p.msg },
+        traceId: $trace, spanId: $span,
+        attributes: [
+          { key: "ci.job.name", value: { stringValue: $jobname } },
+          { key: "ci.job.id",   value: { stringValue: $jobid } } ] })
+| { resourceLogs: [ {
+      resource: { attributes: [
+        { key: "service.name", value: { stringValue: $service } } ] },
+      scopeLogs: [ { scope: { name: "github-actions-exporter" }, logRecords: . } ] } ] }
+'
+
+# --- one child span + correlated logs per completed job ---
+jq -r '.jobs[] | select(.started_at != null and .completed_at != null)
+        | [.name, (.conclusion // .status), .started_at, .completed_at, (.id|tostring)] | @tsv' jobs.json |
+while IFS="$(printf '\t')" read -r name status started finished id; do
+  echo "  span: ${name} [${status}] ${started} -> ${finished}"
+  SPAN_ID=$(head -c 8 /dev/urandom | od -An -tx1 | tr -d ' \n')
+  # shellcheck disable=SC2086
+  "${OTEL_CLI}" span ${OTEL_ARGS} \
+    --service "${SERVICE_NAME}" \
+    --name "${name}" \
+    --start "${started}" --end "${finished}" \
+    --attrs "ci.job.id=${id},ci.job.status=${status}" \
+    --force-trace-id "${TRACE_ID}" --force-span-id "${SPAN_ID}" \
+    --force-parent-span-id "${ROOT_SPAN_ID}"
+
+  # Ship this job's logs, correlated to its span. Best-effort: a failure here
+  # must not abort the remaining jobs' export.
+  set +e
+  if gh_api "${API}/repos/${GITHUB_REPOSITORY}/actions/jobs/${id}/logs" -o job.log; then
+    default_nanos=$(jq -rn --arg ts "${finished}" \
+      '($ts[0:19] + "Z" | fromdateiso8601 | tostring) + "000000000"')
+    if [ -s job.log ]; then
+      tail -n "${MAX_LINES}" job.log | jq -R -s \
+        --arg trace "${TRACE_ID}" --arg span "${SPAN_ID}" \
+        --arg jobname "${name}" --arg jobid "${id}" \
+        --arg service "${SERVICE_NAME}" --arg defaultNanos "${default_nanos}" \
+        "${LOGS_JQ}" > logs-payload.json
+      if curl -sS --fail -K "${HDR_CONF}" \
+           -H "Content-Type: application/json" \
+           -X POST "${BASE}/v1/logs" --data @logs-payload.json >/dev/null; then
+        echo "    logs sent ($(wc -l < job.log | tr -d ' ') lines, capped ${MAX_LINES})"
+      else
+        echo "    WARNING: log export failed for job ${id}"
+      fi
+    fi
+  else
+    echo "    WARNING: could not fetch logs for job ${id}"
+  fi
+  set -e
+done
+echo "Trace + log export complete."

--- a/scripts/ci/export-otel-github.sh
+++ b/scripts/ci/export-otel-github.sh
@@ -1,9 +1,10 @@
 #!/bin/sh
 # Export the whole GitHub Actions run as an OpenTelemetry trace AND its job
 # logs to ClickStack. One root span for the run plus a child span per job
-# (built from the GitHub Actions API with otel-cli), and every job's log lines
-# shipped as OTLP log records stamped with the same trace id + that job's span
-# id, so logs and spans correlate in the backend.
+# (built from the GitHub Actions API with otel-cli), and one OTLP log record
+# per job (the whole job log as the body) stamped with the same trace id +
+# that job's span id, so logs and spans correlate in the backend without
+# exploding the trace into one span per log line.
 #
 # This is the self-built counterpart to corentinmusard/otel-cicd-action: the
 # action only emits traces and hides the span ids it mints, which makes
@@ -152,37 +153,26 @@ echo "Trace ID: ${TRACE_ID}  Service: ${SERVICE_NAME}"
   --force-trace-id "${TRACE_ID}" --force-span-id "${ROOT_SPAN_ID}"
 echo "Root span sent."
 
-# jq program: turn a plaintext GitHub job log into an OTLP/HTTP JSON logs
-# payload, one log record per line, each carrying trace_id + this job's span_id.
-# GitHub prefixes every line with an RFC3339 timestamp we reuse for the record.
+# jq program: wrap a whole job log (slurped as one string via -R -s) into a
+# single OTLP/HTTP JSON log record carrying trace_id + this job's span_id, so
+# each job contributes ONE correlated log entry rather than one span per line.
 # $trace/$span/etc. are jq variables, not shell — single quotes are correct.
 # shellcheck disable=SC2016
 LOGS_JQ='
-def nanos($ts):
-  ($ts[0:19] + "Z" | fromdateiso8601 | tostring)
-  + ((( ($ts | capture("\\.(?<f>[0-9]+)Z$") | .f) // "") + "000000000")[0:9]);
-def parse($line):
-  if ($line | test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.]+Z "))
-  then ($line | capture("^(?<ts>\\S+) (?<msg>.*)$"))
-  else {ts: null, msg: $line} end;
-def sev($msg):
-  if   ($msg | test("##\\[error\\]"))   then {t:"ERROR", n:17}
-  elif ($msg | test("##\\[warning\\]")) then {t:"WARN",  n:13}
-  else {t:"INFO", n:9} end;
-split("\n")
-| map(select(length > 0))
-| map(parse(.) as $p | sev($p.msg) as $s
-    | { timeUnixNano: (if $p.ts then nanos($p.ts) else $defaultNanos end),
-        severityText: $s.t, severityNumber: $s.n,
-        body: { stringValue: $p.msg },
+{ resourceLogs: [ {
+    resource: { attributes: [
+      { key: "service.name", value: { stringValue: $service } } ] },
+    scopeLogs: [ { scope: { name: "github-actions-exporter" },
+      logRecords: [ {
+        timeUnixNano: $nanos,
+        severityText: $severity,
+        severityNumber: ($sevnum | tonumber),
+        body: { stringValue: . },
         traceId: $trace, spanId: $span,
         attributes: [
-          { key: "ci.job.name", value: { stringValue: $jobname } },
-          { key: "ci.job.id",   value: { stringValue: $jobid } } ] })
-| { resourceLogs: [ {
-      resource: { attributes: [
-        { key: "service.name", value: { stringValue: $service } } ] },
-      scopeLogs: [ { scope: { name: "github-actions-exporter" }, logRecords: . } ] } ] }
+          { key: "ci.job.name",   value: { stringValue: $jobname } },
+          { key: "ci.job.id",     value: { stringValue: $jobid } },
+          { key: "ci.job.status", value: { stringValue: $jobstatus } } ] } ] } ] } ] }
 '
 
 # --- one child span + correlated logs per completed job ---
@@ -200,22 +190,28 @@ while IFS="$(printf '\t')" read -r name status started finished id; do
     --force-trace-id "${TRACE_ID}" --force-span-id "${SPAN_ID}" \
     --force-parent-span-id "${ROOT_SPAN_ID}"
 
-  # Ship this job's logs, correlated to its span. Best-effort: a failure here
-  # must not abort the remaining jobs' export.
+  # Ship this job's log as a single correlated record. Best-effort: a failure
+  # here must not abort the remaining jobs' export.
+  case "${status}" in
+    failure)                        sev_text=ERROR; sev_num=17 ;;
+    cancelled|timed_out|action_required) sev_text=WARN; sev_num=13 ;;
+    *)                              sev_text=INFO;  sev_num=9  ;;
+  esac
   set +e
   if gh_api "${API}/repos/${GITHUB_REPOSITORY}/actions/jobs/${id}/logs" -o job.log; then
-    default_nanos=$(jq -rn --arg ts "${finished}" \
+    nanos=$(jq -rn --arg ts "${finished}" \
       '($ts[0:19] + "Z" | fromdateiso8601 | tostring) + "000000000"')
     if [ -s job.log ]; then
       tail -n "${MAX_LINES}" job.log | jq -R -s \
         --arg trace "${TRACE_ID}" --arg span "${SPAN_ID}" \
-        --arg jobname "${name}" --arg jobid "${id}" \
-        --arg service "${SERVICE_NAME}" --arg defaultNanos "${default_nanos}" \
+        --arg jobname "${name}" --arg jobid "${id}" --arg jobstatus "${status}" \
+        --arg service "${SERVICE_NAME}" --arg nanos "${nanos}" \
+        --arg severity "${sev_text}" --arg sevnum "${sev_num}" \
         "${LOGS_JQ}" > logs-payload.json
       if curl -sS --fail -K "${HDR_CONF}" \
            -H "Content-Type: application/json" \
            -X POST "${LOGS_ENDPOINT}" --data @logs-payload.json >/dev/null; then
-        echo "    logs sent ($(wc -l < job.log | tr -d ' ') lines, capped ${MAX_LINES})"
+        echo "    log sent (1 record, $(wc -l < job.log | tr -d ' ') lines, capped ${MAX_LINES})"
       else
         echo "    WARNING: log export failed for job ${id}"
       fi

--- a/scripts/ci/export-otel-github.sh
+++ b/scripts/ci/export-otel-github.sh
@@ -130,8 +130,8 @@ jq '{jobs: .}' jobs-acc.json > jobs.json
 echo "Jobs fetched: $(jq '.jobs | length' jobs.json) across ${page} page(s), completed: $(jq '[.jobs[]|select(.completed_at!=null)]|length' jobs.json)"
 
 # --- run span boundaries from job timestamps ---
-RUN_START=$(jq -r '[.jobs[].started_at   | select(. != null)] | min // empty' jobs.json)
-RUN_END=$(jq   -r '[.jobs[].completed_at | select(. != null)] | max // empty' jobs.json)
+RUN_START=$(jq -r '[.jobs[].started_at   | select(. != null)] | min // empty' "${BIN_DIR}/jobs.json")
+RUN_END=$(jq   -r '[.jobs[].completed_at | select(. != null)] | max // empty' "${BIN_DIR}/jobs.json")
 : "${RUN_START:?no started jobs found - nothing to export}"
 : "${RUN_END:=$RUN_START}"
 echo "Run window: ${RUN_START} -> ${RUN_END}"
@@ -177,7 +177,7 @@ LOGS_JQ='
 
 # --- one child span + correlated logs per completed job ---
 jq -r '.jobs[] | select(.started_at != null and .completed_at != null)
-        | [.name, (.conclusion // .status), .started_at, .completed_at, (.id|tostring)] | @tsv' jobs.json |
+        | [.name, (.conclusion // .status), .started_at, .completed_at, (.id|tostring)] | @tsv' "${BIN_DIR}/jobs.json" |
 while IFS="$(printf '\t')" read -r name status started finished id; do
   echo "  span: ${name} [${status}] ${started} -> ${finished}"
   SPAN_ID=$(head -c 8 /dev/urandom | od -An -tx1 | tr -d ' \n')

--- a/scripts/ci/export-otel-github.sh
+++ b/scripts/ci/export-otel-github.sh
@@ -63,6 +63,7 @@ cleanup() {
       case "${HOSTS_MODE}" in
         direct) cat "${_h}" > /etc/hosts 2>/dev/null || true ;;
         sudo)   sudo -n cp "${_h}" /etc/hosts >/dev/null 2>&1 || true ;;
+        *)      : ;;  # no write happened; nothing to restore
       esac
     fi
   fi

--- a/scripts/ci/export-otel-github.sh
+++ b/scripts/ci/export-otel-github.sh
@@ -23,7 +23,16 @@ set -eu
 
 : "${OTEL_EXPORTER_OTLP_ENDPOINT:?OTEL_EXPORTER_OTLP_ENDPOINT not set}"
 : "${GITHUB_TOKEN:?GITHUB_TOKEN not set}"
+# OTEL_EXPORTER_OTLP_ENDPOINT is the collector BASE URL (no signal path). Both
+# signals are derived from it: traces -> ${BASE}/v1/traces (appended by
+# otel-cli), logs -> ${BASE}/v1/logs (our raw POST). Tolerate a value that
+# accidentally includes a trailing slash or signal path so the two never drift.
 BASE=${OTEL_EXPORTER_OTLP_ENDPOINT%/}
+BASE=${BASE%/v1/traces}
+BASE=${BASE%/v1/logs}
+BASE=${BASE%/}
+TRACES_ENDPOINT="${BASE}/v1/traces"
+LOGS_ENDPOINT="${BASE}/v1/logs"
 MAX_LINES=${OTEL_LOG_MAX_LINES:-2000}
 API=${GITHUB_API_URL:-https://api.github.com}
 ATTEMPT=${GITHUB_RUN_ATTEMPT:-1}
@@ -35,6 +44,9 @@ command -v jq   >/dev/null 2>&1 || { echo "jq not found"; exit 1; }
 # Local dir avoids needing root/sudo on the self-hosted runner.
 echo "Installing otel-cli v${OTEL_CLI_VERSION}..."
 BIN_DIR=$(mktemp -d)
+# Clean up the temp dir (binary, checksums, header config, scratch files) so we
+# don't accumulate artifacts on long-lived self-hosted runners.
+trap 'rm -rf "${BIN_DIR}"' EXIT
 GH="https://github.com/equinix-labs/otel-cli/releases/download/v${OTEL_CLI_VERSION}"
 TARBALL="otel-cli_${OTEL_CLI_VERSION}_linux_amd64.tar.gz"
 curl --proto "=https" -sSfL -o "${BIN_DIR}/${TARBALL}" "${GH}/${TARBALL}"
@@ -43,20 +55,23 @@ curl --proto "=https" -sSfL -o "${BIN_DIR}/checksums.txt" "${GH}/checksums.txt"
 tar -xzf "${BIN_DIR}/${TARBALL}" -C "${BIN_DIR}" otel-cli
 OTEL_CLI="${BIN_DIR}/otel-cli"
 
-# otel-cli defaults to gRPC; force HTTP and surface export failures.
-OTEL_ARGS="--protocol http/protobuf --endpoint ${OTEL_EXPORTER_OTLP_ENDPOINT} --fail --verbose"
-echo "Endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT} (traces -> /v1/traces, logs -> /v1/logs)"
+# otel-cli defaults to gRPC; force HTTP and surface export failures. It appends
+# the /v1/traces signal path to the base endpoint itself.
+OTEL_ARGS="--protocol http/protobuf --endpoint ${BASE} --fail --verbose"
+echo "Traces -> ${TRACES_ENDPOINT}, logs -> ${LOGS_ENDPOINT}"
 
 # The runner may resolve via LAN DNS and be unable to resolve the Tailscale
-# MagicDNS name. Optionally map the hostname to a reachable IP (best-effort;
-# needs write access to /etc/hosts, so try sudo and never fail the job).
+# MagicDNS name. Optionally map the hostname to a reachable IP. This only runs
+# when OTEL_ENDPOINT_HOST_IP is set (opt-in), and only escalates via sudo when
+# OTEL_HOSTS_SUDO is explicitly enabled — otherwise a non-writable /etc/hosts
+# just warns and falls back to DNS. It never fails the job.
 OTEL_HOST=${OTEL_EXPORTER_OTLP_ENDPOINT#*://}
 OTEL_HOST=${OTEL_HOST%%/*}
 OTEL_HOST=${OTEL_HOST%%:*}
 if [ -n "${OTEL_ENDPOINT_HOST_IP:-}" ]; then
   if echo "${OTEL_ENDPOINT_HOST_IP} ${OTEL_HOST}" >> /etc/hosts 2>/dev/null; then
     echo "Mapped ${OTEL_HOST} -> ${OTEL_ENDPOINT_HOST_IP} via /etc/hosts"
-  elif command -v sudo >/dev/null 2>&1 &&
+  elif [ "${OTEL_HOSTS_SUDO:-}" = "1" ] && command -v sudo >/dev/null 2>&1 &&
        echo "${OTEL_ENDPOINT_HOST_IP} ${OTEL_HOST}" | sudo -n tee -a /etc/hosts >/dev/null 2>&1; then
     echo "Mapped ${OTEL_HOST} -> ${OTEL_ENDPOINT_HOST_IP} via /etc/hosts (sudo)"
   else
@@ -82,6 +97,10 @@ while [ -n "${headers}" ]; do
   printf 'header = "%s: %s"\n' "${key}" "${val}" >> "${HDR_CONF}"
 done
 
+# Keep all scratch (jobs.json, per-job logs, payloads) inside BIN_DIR so the
+# EXIT trap removes it too. Nothing below this point needs the repo checkout.
+cd "${BIN_DIR}"
+
 # --- fetch this run's jobs from the GitHub API ---
 gh_api() {
   curl -sSfL \
@@ -90,9 +109,24 @@ gh_api() {
     -H "X-GitHub-Api-Version: 2022-11-28" \
     "$@"
 }
-gh_api "${API}/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${ATTEMPT}/jobs?per_page=100" \
-  > jobs.json
-echo "Jobs fetched: $(jq '.jobs | length' jobs.json), completed: $(jq '[.jobs[]|select(.completed_at!=null)]|length' jobs.json)"
+# Paginate: the jobs API caps at 100 per page, so follow pages until we've
+# collected total_count, merging each page's .jobs into a single {jobs:[...]}.
+JOBS_URL="${API}/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${ATTEMPT}/jobs"
+echo '[]' > jobs-acc.json
+page=1
+while :; do
+  gh_api "${JOBS_URL}?per_page=100&page=${page}" > jobs-page.json
+  jq -s '.[0] + .[1].jobs' jobs-acc.json jobs-page.json > jobs-acc.tmp
+  mv jobs-acc.tmp jobs-acc.json
+  total=$(jq -r '.total_count' jobs-page.json)
+  got=$(jq -r '.jobs | length' jobs-page.json)
+  have=$(jq -r 'length' jobs-acc.json)
+  [ "${got}" -eq 0 ] && break
+  [ "${have}" -ge "${total}" ] && break
+  page=$((page + 1))
+done
+jq '{jobs: .}' jobs-acc.json > jobs.json
+echo "Jobs fetched: $(jq '.jobs | length' jobs.json) across ${page} page(s), completed: $(jq '[.jobs[]|select(.completed_at!=null)]|length' jobs.json)"
 
 # --- run span boundaries from job timestamps ---
 RUN_START=$(jq -r '[.jobs[].started_at   | select(. != null)] | min // empty' jobs.json)
@@ -180,7 +214,7 @@ while IFS="$(printf '\t')" read -r name status started finished id; do
         "${LOGS_JQ}" > logs-payload.json
       if curl -sS --fail -K "${HDR_CONF}" \
            -H "Content-Type: application/json" \
-           -X POST "${BASE}/v1/logs" --data @logs-payload.json >/dev/null; then
+           -X POST "${LOGS_ENDPOINT}" --data @logs-payload.json >/dev/null; then
         echo "    logs sent ($(wc -l < job.log | tr -d ' ') lines, capped ${MAX_LINES})"
       else
         echo "    WARNING: log export failed for job ${id}"

--- a/scripts/ci/export-otel-github.sh
+++ b/scripts/ci/export-otel-github.sh
@@ -35,6 +35,12 @@ BASE=${BASE%/}
 TRACES_ENDPOINT="${BASE}/v1/traces"
 LOGS_ENDPOINT="${BASE}/v1/logs"
 MAX_LINES=${OTEL_LOG_MAX_LINES:-2000}
+# Only accept a positive integer; otherwise fall back to the default so a bad
+# value can't make `tail -n` error (non-numeric) or emit nothing (0).
+case "${MAX_LINES}" in
+  ''|*[!0-9]*) echo "WARNING: OTEL_LOG_MAX_LINES='${MAX_LINES}' is not a number; using 2000"; MAX_LINES=2000 ;;
+esac
+[ "${MAX_LINES}" -ge 1 ] 2>/dev/null || { echo "WARNING: OTEL_LOG_MAX_LINES must be >= 1; using 2000"; MAX_LINES=2000; }
 API=${GITHUB_API_URL:-https://api.github.com}
 ATTEMPT=${GITHUB_RUN_ATTEMPT:-1}
 
@@ -45,13 +51,30 @@ command -v jq   >/dev/null 2>&1 || { echo "jq not found"; exit 1; }
 # Local dir avoids needing root/sudo on the self-hosted runner.
 echo "Installing otel-cli v${OTEL_CLI_VERSION}..."
 BIN_DIR=$(mktemp -d)
-# Clean up the temp dir (binary, checksums, header config, scratch files) so we
-# don't accumulate artifacts on long-lived self-hosted runners.
-trap 'rm -rf "${BIN_DIR}"' EXIT
+HOSTS_MARKER=""
+HOSTS_MODE=""
+# Clean up the temp dir (binary, checksums, header config, scratch files) and
+# any /etc/hosts line we added, so we don't accumulate artifacts on long-lived
+# self-hosted runners.
+cleanup() {
+  if [ -n "${HOSTS_MARKER}" ]; then
+    _h="${BIN_DIR}/hosts.clean"
+    if grep -F -v "${HOSTS_MARKER}" /etc/hosts > "${_h}" 2>/dev/null; then
+      case "${HOSTS_MODE}" in
+        direct) cat "${_h}" > /etc/hosts 2>/dev/null || true ;;
+        sudo)   sudo -n cp "${_h}" /etc/hosts >/dev/null 2>&1 || true ;;
+      esac
+    fi
+  fi
+  rm -rf "${BIN_DIR}"
+}
+trap cleanup EXIT
 GH="https://github.com/equinix-labs/otel-cli/releases/download/v${OTEL_CLI_VERSION}"
 TARBALL="otel-cli_${OTEL_CLI_VERSION}_linux_amd64.tar.gz"
-curl --proto "=https" -sSfL -o "${BIN_DIR}/${TARBALL}" "${GH}/${TARBALL}"
-curl --proto "=https" -sSfL -o "${BIN_DIR}/checksums.txt" "${GH}/checksums.txt"
+curl --proto "=https" --connect-timeout 10 --max-time 120 --retry 3 --retry-connrefused \
+  -sSfL -o "${BIN_DIR}/${TARBALL}" "${GH}/${TARBALL}"
+curl --proto "=https" --connect-timeout 10 --max-time 120 --retry 3 --retry-connrefused \
+  -sSfL -o "${BIN_DIR}/checksums.txt" "${GH}/checksums.txt"
 ( cd "${BIN_DIR}" && grep " ${TARBALL}\$" checksums.txt | sha256sum -c - )
 tar -xzf "${BIN_DIR}/${TARBALL}" -C "${BIN_DIR}" otel-cli
 OTEL_CLI="${BIN_DIR}/otel-cli"
@@ -70,12 +93,19 @@ OTEL_HOST=${OTEL_EXPORTER_OTLP_ENDPOINT#*://}
 OTEL_HOST=${OTEL_HOST%%/*}
 OTEL_HOST=${OTEL_HOST%%:*}
 if [ -n "${OTEL_ENDPOINT_HOST_IP:-}" ]; then
-  if echo "${OTEL_ENDPOINT_HOST_IP} ${OTEL_HOST}" >> /etc/hosts 2>/dev/null; then
+  # Trailing comment marker makes the line uniquely matchable so cleanup() can
+  # remove exactly what we added (and nothing else) on exit.
+  HOSTS_MARKER="# otel-export ${GITHUB_RUN_ID:-}-${ATTEMPT}-$$"
+  _line="${OTEL_ENDPOINT_HOST_IP} ${OTEL_HOST} ${HOSTS_MARKER}"
+  if printf '%s\n' "${_line}" >> /etc/hosts 2>/dev/null; then
+    HOSTS_MODE=direct
     echo "Mapped ${OTEL_HOST} -> ${OTEL_ENDPOINT_HOST_IP} via /etc/hosts"
   elif [ "${OTEL_HOSTS_SUDO:-}" = "1" ] && command -v sudo >/dev/null 2>&1 &&
-       echo "${OTEL_ENDPOINT_HOST_IP} ${OTEL_HOST}" | sudo -n tee -a /etc/hosts >/dev/null 2>&1; then
+       printf '%s\n' "${_line}" | sudo -n tee -a /etc/hosts >/dev/null 2>&1; then
+    HOSTS_MODE=sudo
     echo "Mapped ${OTEL_HOST} -> ${OTEL_ENDPOINT_HOST_IP} via /etc/hosts (sudo)"
   else
+    HOSTS_MARKER=""  # nothing written; leave /etc/hosts untouched at cleanup
     echo "WARNING: could not write /etc/hosts; relying on DNS for ${OTEL_HOST}"
   fi
 fi
@@ -86,6 +116,9 @@ fi
 # tampering with IFS globally.
 HDR_CONF="${BIN_DIR}/otlp-headers.conf"
 : > "${HDR_CONF}"
+# Escape backslashes and double quotes and strip CR/LF so a header value can't
+# break the quoted `header = "..."` lines in the curl -K config.
+esc_hdr() { printf '%s' "$1" | tr -d '\r\n' | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'; }
 headers=${OTEL_EXPORTER_OTLP_HEADERS:-}
 while [ -n "${headers}" ]; do
   case "${headers}" in
@@ -93,8 +126,8 @@ while [ -n "${headers}" ]; do
     *)   pair=${headers};     headers= ;;
   esac
   [ -n "${pair}" ] || continue
-  key=${pair%%=*}
-  val=${pair#*=}
+  key=$(esc_hdr "${pair%%=*}")
+  val=$(esc_hdr "${pair#*=}")
   printf 'header = "%s: %s"\n' "${key}" "${val}" >> "${HDR_CONF}"
 done
 
@@ -104,7 +137,7 @@ cd "${BIN_DIR}"
 
 # --- fetch this run's jobs from the GitHub API ---
 gh_api() {
-  curl -sSfL \
+  curl -sSfL --connect-timeout 10 --max-time 120 --retry 3 --retry-connrefused \
     -H "Accept: application/vnd.github+json" \
     -H "Authorization: Bearer ${GITHUB_TOKEN}" \
     -H "X-GitHub-Api-Version: 2022-11-28" \
@@ -216,7 +249,8 @@ while IFS="$(printf '\t')" read -r name status started finished id; do
         "${LOGS_JQ}" > logs-payload.json; then
       # --data-binary (not --data): --data strips newlines from file input,
       # which would concatenate the log lines; --data-binary sends bytes as-is.
-      if curl -sS --fail -K "${HDR_CONF}" \
+      # No --retry: a POST isn't idempotent, so bound it with timeouts only.
+      if curl -sS --fail --connect-timeout 10 --max-time 60 -K "${HDR_CONF}" \
            -H "Content-Type: application/json" \
            -X POST "${LOGS_ENDPOINT}" --data-binary @logs-payload.json >/dev/null; then
         echo "    log sent (1 record, $(wc -l < job.log | tr -d ' ') lines, capped ${MAX_LINES})"

--- a/scripts/ci/export-otel-github.sh
+++ b/scripts/ci/export-otel-github.sh
@@ -119,7 +119,10 @@ HDR_CONF="${BIN_DIR}/otlp-headers.conf"
 : > "${HDR_CONF}"
 # Escape backslashes and double quotes and strip CR/LF so a header value can't
 # break the quoted `header = "..."` lines in the curl -K config.
-esc_hdr() { printf '%s' "$1" | tr -d '\r\n' | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'; }
+esc_hdr() {
+  _hv=$1
+  printf '%s' "${_hv}" | tr -d '\r\n' | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
+}
 headers=${OTEL_EXPORTER_OTLP_HEADERS:-}
 while [ -n "${headers}" ]; do
   case "${headers}" in

--- a/scripts/ci/export-otel-github.sh
+++ b/scripts/ci/export-otel-github.sh
@@ -202,15 +202,20 @@ while IFS="$(printf '\t')" read -r name status started finished id; do
     nanos=$(jq -rn --arg ts "${finished}" \
       '($ts[0:19] + "Z" | fromdateiso8601 | tostring) + "000000000"')
     if [ -s job.log ]; then
-      tail -n "${MAX_LINES}" job.log | jq -R -s \
+      # Normalize CRLF -> LF so the body carries clean \n line breaks, then
+      # emit compact JSON (-c) so the payload's only real newlines are the
+      # in-string \n escapes.
+      tr -d '\r' < job.log | tail -n "${MAX_LINES}" | jq -R -s -c \
         --arg trace "${TRACE_ID}" --arg span "${SPAN_ID}" \
         --arg jobname "${name}" --arg jobid "${id}" --arg jobstatus "${status}" \
         --arg service "${SERVICE_NAME}" --arg nanos "${nanos}" \
         --arg severity "${sev_text}" --arg sevnum "${sev_num}" \
         "${LOGS_JQ}" > logs-payload.json
+      # --data-binary (not --data): --data strips newlines from file input,
+      # which would concatenate the log lines; --data-binary sends bytes as-is.
       if curl -sS --fail -K "${HDR_CONF}" \
            -H "Content-Type: application/json" \
-           -X POST "${LOGS_ENDPOINT}" --data @logs-payload.json >/dev/null; then
+           -X POST "${LOGS_ENDPOINT}" --data-binary @logs-payload.json >/dev/null; then
         echo "    log sent (1 record, $(wc -l < job.log | tr -d ' ') lines, capped ${MAX_LINES})"
       else
         echo "    WARNING: log export failed for job ${id}"


### PR DESCRIPTION
Replace corentinmusard/otel-cicd-action with a self-built exporter so CI job logs correlate with their spans. The action only emits traces and hides the span ids it mints, which makes log<->span correlation impossible.

The new scripts/ci/export-otel-github.sh mirrors the GitLab export-otel-trace.sh: it forces its own trace id, root span id, and per-job span ids, emits a root span plus one child span per job via otel-cli, then ships each job's logs as OTLP log records stamped with the trace id and that job's span id to /v1/logs. Spans and logs now correlate in ClickStack.

Per-line RFC3339 timestamps are preserved to nanosecond precision, GitHub ##[error]/##[warning] markers map to OTLP severity, log volume is capped per job, and log-export failures never abort the trace export.

## Summary by Sourcery

Replace the third-party OpenTelemetry CI action with a custom GitHub-based exporter that emits both traces and job logs with shared trace/span IDs for backend correlation.

New Features:
- Introduce a scripts/ci/export-otel-github.sh helper that exports GitHub Actions runs as OpenTelemetry traces plus per-job logs with correlated trace and span IDs.

Enhancements:
- Update the CI workflow to use a dedicated otel-export job that installs otel-cli, hardens the runner, and exports telemetry via a configurable OTLP endpoint, while tolerating export failures.

CI:
- Refine the GitHub Actions workflow OTEL export job configuration, including environment wiring for OTLP settings, endpoint guarding, and runner hardening via step-security.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - CI telemetry now exports workflow traces and correlated job logs for improved pipeline observability.
- **Bug Fixes**
  - Telemetry export is hardened with a time limit and best-effort behavior so failures don’t break the overall CI workflow.
  - If no OTLP endpoint is configured, telemetry export is automatically skipped.
  - Job log export continues even if an individual job’s export encounters issues.
- **Chores**
  - Updated automation settings for digest-based update release-age handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->