### PR TITLE
Feature review spending habits

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,12 @@ DAILY_REMINDER_ENABLED=false
 REMINDER_HOUR=20
 REMINDER_TIMEZONE=Asia/Singapore
 
+# Weekly report settings (optional)
+WEEKLY_REPORT_ENABLED=false
+WEEKLY_REPORT_DAY=1
+WEEKLY_REPORT_HOUR=9
+WEEKLY_HABIT_RECAP_ENABLED=false
+
 # OpenTelemetry settings (optional)
 OTEL_ENABLED=false
 OTEL_SERVICE_NAME=expense-bot
@@ -478,6 +484,10 @@ The project uses:
 | `DAILY_REMINDER_ENABLED` | No | Enable daily reminders for users without expenses (`true`/`false`) | false |
 | `REMINDER_HOUR` | No | Hour of day to send reminders (0-23) | 20 |
 | `REMINDER_TIMEZONE` | No | IANA timezone for reminder scheduling and display | Asia/Singapore |
+| `WEEKLY_REPORT_ENABLED` | No | Enable the weekly expense summary push (`true`/`false`) | false |
+| `WEEKLY_REPORT_DAY` | No | Day of week to send the weekly report (0=Sunday .. 6=Saturday) | 1 (Monday) |
+| `WEEKLY_REPORT_HOUR` | No | Hour of day to send the weekly report (0-23), per-user timezone | 9 |
+| `WEEKLY_HABIT_RECAP_ENABLED` | No | Send the previous week's spending reflection recap with the weekly report (`true`/`false`) | false |
 | `OTEL_ENABLED` | No | Enable OpenTelemetry tracing/metrics (`true`/`false`) | false |
 | `OTEL_SERVICE_NAME` | No | OTel `service.name` resource attribute | `expense-bot` |
 | `OTEL_ENVIRONMENT` | No | OTel deployment environment attribute | `production` |

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ REMINDER_TIMEZONE=Asia/Singapore
 WEEKLY_REPORT_ENABLED=false
 WEEKLY_REPORT_DAY=1
 WEEKLY_REPORT_HOUR=9
+# Requires WEEKLY_REPORT_ENABLED=true; the recap is sent with the weekly report
 WEEKLY_HABIT_RECAP_ENABLED=false
 
 # OpenTelemetry settings (optional)
@@ -487,7 +488,7 @@ The project uses:
 | `WEEKLY_REPORT_ENABLED` | No | Enable the weekly expense summary push (`true`/`false`) | false |
 | `WEEKLY_REPORT_DAY` | No | Day of week to send the weekly report (0=Sunday .. 6=Saturday) | 1 (Monday) |
 | `WEEKLY_REPORT_HOUR` | No | Hour of day to send the weekly report (0-23), per-user timezone | 9 |
-| `WEEKLY_HABIT_RECAP_ENABLED` | No | Send the previous week's spending reflection recap with the weekly report (`true`/`false`) | false |
+| `WEEKLY_HABIT_RECAP_ENABLED` | No | Send the previous week's spending reflection recap with the weekly report (`true`/`false`); only takes effect when `WEEKLY_REPORT_ENABLED=true` | false |
 | `OTEL_ENABLED` | No | Enable OpenTelemetry tracing/metrics (`true`/`false`) | false |
 | `OTEL_SERVICE_NAME` | No | OTel `service.name` resource attribute | `expense-bot` |
 | `OTEL_ENVIRONMENT` | No | OTel deployment environment attribute | `production` |

--- a/docs/WEEKLY_HABIT_RECAP_PLAN.md
+++ b/docs/WEEKLY_HABIT_RECAP_PLAN.md
@@ -1,0 +1,152 @@
+# Weekly Habit Recap Plan
+
+## Context
+
+The spending reflection feature (`/review` + `/habit`, see
+`SPENDING_REFLECTION_PLAN.md`) is live, but the recap is pull-only: users must
+remember to run `/habit`. The doc's "Future Extensions" list includes a
+scheduled reflection recap. This plan delivers that as a **weekly** push,
+riding on the existing weekly report loop: when a user receives their weekly
+expense summary, they also receive their spending reflection recap for the
+same previous week.
+
+Goal: users see their worth-it / not-worth-it patterns weekly without asking,
+using only data they already reviewed. No new data model changes are needed.
+
+## Design
+
+### Delivery
+
+Piggyback on the existing weekly report loop rather than adding a second
+ticker loop:
+
+- `startWeeklyReportLoop` / `checkAndSendWeeklyReports` /
+  `processWeeklyReportUser` in `internal/bot/weekly_report.go` already handle
+  per-user timezone gating (`WeeklyReportDay`/`WeeklyReportHour`), weekly
+  dedup (`sent map[int64]string` keyed by previous-week start), pruning, and
+  OTel metrics.
+- In `processWeeklyReportUser`, after `sendWeeklySummary` returns
+  `(true, nil)`, call a new `sendWeeklyHabitRecap(ctx, user, userNow)`.
+- The recap is **best-effort**: a recap failure is logged but does not block
+  marking the week as sent. This keeps at-most-once semantics for the weekly
+  summary (no risk of double summary on retry).
+- If the weekly summary is skipped (no expenses that week), the recap is
+  skipped too — reviewed expenses in the range are a subset of expenses in
+  the range (`GetReviewedByUserIDAndDateRange` filters on `created_at`).
+
+### New function: `sendWeeklyHabitRecap`
+
+Add alongside `sendWeeklySummary` in `internal/bot/weekly_report.go`:
+
+```go
+// sendWeeklyHabitRecap sends the previous week's spending reflection
+// recap. Returns (false, nil) when there is nothing to send.
+func (b *Bot) sendWeeklyHabitRecap(
+    ctx context.Context,
+    user *appmodels.User,
+    userNow time.Time,
+) (bool, error)
+```
+
+Behavior (all pieces already exist — this is composition only):
+
+1. Range: `getPreviousWeekRangeAt(userNow)` (`internal/bot/date_range.go:84`).
+2. Fetch: `b.expenseRepo.GetByUserIDAndDateRange` (total count) and
+   `b.expenseRepo.GetReviewedByUserIDAndDateRange` (reflected expenses), same
+   as `handleHabitCore` (`internal/bot/handlers_habit.go:100-112`).
+3. **Skip silently when there are no reviewed expenses** in the range
+   (return `(false, nil)`). A weekly "please run /review" nudge would be
+   noise; the recap only appears when the user has reflection data.
+4. Analyze: `analyzeExpenseHabit(len(expenses), reviewed, loc, label)`
+   (`internal/bot/habit_analyzer.go:62`) with a previous-week label in the
+   same style as the weekly summary header, e.g.
+   `prevStart.Format("Jan 2") + " to " + prevEnd.AddDate(0,0,-1).Format("Jan 2, 2006")`.
+5. Format: `formatHabitSummary(&summary)`
+   (`internal/bot/handlers_habit.go:524`) — reuse unchanged so `/habit` and
+   the scheduled recap always render identically.
+6. Send via `b.messageSender.SendMessage` with `ParseModeHTML`, as
+   `sendWeeklySummary` does.
+
+Timezone: use `b.userLocation(user.Timezone)` (already computed in
+`processWeeklyReportUser`; pass `loc` in or recompute — match whichever is
+cleaner at the call site).
+
+### Config
+
+New env flag, following the `applyWeeklyReportConfig` pattern in
+`internal/config/config.go:143`:
+
+- `Config.WeeklyHabitRecapEnabled bool`
+- `WEEKLY_HABIT_RECAP_ENABLED=true` to enable; default **false**.
+- Effective only when `WEEKLY_REPORT_ENABLED=true`, since the recap rides the
+  weekly report loop. Log a startup warning if the recap flag is set while
+  the weekly report is disabled.
+
+`processWeeklyReportUser` checks `b.cfg.WeeklyHabitRecapEnabled` before
+calling `sendWeeklyHabitRecap`.
+
+### Observability
+
+- Log success/failure with `logger.HashUserID(user.ID)`, mirroring the
+  existing weekly report logs.
+- Existing `recordWeeklyReportMetrics` continues to cover the loop. Add a
+  `BackgroundJobRuns` counter increment with
+  `attribute.String("job", "weekly_habit_recap")` on each send attempt
+  (status `ok`/`error`) so recap volume is visible separately.
+
+## Files to change
+
+| File | Change |
+|------|--------|
+| `internal/bot/weekly_report.go` | Add `sendWeeklyHabitRecap`; call it from `processWeeklyReportUser` behind the config flag; recap metrics/logs |
+| `internal/config/config.go` | `WeeklyHabitRecapEnabled` field + env parsing in/next to `applyWeeklyReportConfig` |
+| `internal/config/config_test.go` | Env parsing tests (enabled/disabled/default), mirroring `TestLoad_WeeklyReport` |
+| `internal/bot/weekly_report_test.go` (or new `weekly_habit_recap_test.go`) | Handler-level tests with `mocks.NewMockBot()` |
+| `README.md` | Env var table + feature note under spending reflection |
+| `.env.example` (if present) | `WEEKLY_HABIT_RECAP_ENABLED` |
+
+No migrations, no repository changes, no new commands, no callback changes.
+
+## Tests
+
+Unit tests using `internal/testutil` mocks (`mocks.NewMockBot()`), table-driven:
+
+- `sendWeeklyHabitRecap`:
+  - No expenses in previous week → `(false, nil)`, nothing sent.
+  - Expenses but none reviewed → `(false, nil)`, nothing sent.
+  - Reviewed expenses → one HTML message sent; body matches
+    `formatHabitSummary` output with the previous-week label.
+  - Repo error → `(false, err)`.
+- `processWeeklyReportUser`:
+  - Flag enabled + summary sent → recap message follows the summary.
+  - Flag disabled → only the summary is sent.
+  - Recap send failure → week still marked in `sent` map, error logged.
+- Config: `WEEKLY_HABIT_RECAP_ENABLED` true/false/unset.
+
+Existing `analyzeExpenseHabit` / `formatHabitSummary` tests already cover the
+analysis and rendering; do not duplicate them here.
+
+## Verification
+
+```bash
+mise run fmt
+mise run test
+mise run test-race
+mise run test-integration   # needs TEST_DATABASE_URL (docker-compose.test.yml)
+```
+
+Coverage must stay at or above 50%.
+
+Manual smoke test: run the bot with `WEEKLY_REPORT_ENABLED=true`,
+`WEEKLY_HABIT_RECAP_ENABLED=true`, and `WEEKLY_REPORT_DAY`/`WEEKLY_REPORT_HOUR`
+set to the current local day/hour; confirm a user with reviewed expenses from
+last week receives both the weekly summary and the reflection recap, and a
+user with no reviewed expenses receives only the summary.
+
+## Out of scope (future)
+
+- Monthly cadence (would need its own loop or a cadence option).
+- Gemini-generated narrative recap.
+- Charts comparing worth-it vs not-worth-it spend.
+- Per-user opt-in/opt-out command (flag is global for now, consistent with
+  the existing weekly report).

--- a/docs/WEEKLY_HABIT_RECAP_PLAN.md
+++ b/docs/WEEKLY_HABIT_RECAP_PLAN.md
@@ -40,24 +40,28 @@ Add alongside `sendWeeklySummary` in `internal/bot/weekly_report.go`:
 
 ```go
 // sendWeeklyHabitRecap sends the previous week's spending reflection
-// recap. Returns (false, nil) when there is nothing to send.
+// recap. totalCount is the expense count sendWeeklySummary already
+// fetched for the same week. Returns (false, nil) when there is
+// nothing to send.
 func (b *Bot) sendWeeklyHabitRecap(
     ctx context.Context,
     user *appmodels.User,
     userNow time.Time,
+    totalCount int,
 ) (bool, error)
 ```
 
 Behavior (all pieces already exist — this is composition only):
 
 1. Range: `getPreviousWeekRangeAt(userNow)` (`internal/bot/date_range.go:84`).
-2. Fetch: `b.expenseRepo.GetByUserIDAndDateRange` (total count) and
-   `b.expenseRepo.GetReviewedByUserIDAndDateRange` (reflected expenses), same
-   as `handleHabitCore` (`internal/bot/handlers_habit.go:100-112`).
+2. Fetch only `b.expenseRepo.GetReviewedByUserIDAndDateRange` (reflected
+   expenses). The total expense count is threaded through from
+   `sendWeeklySummary` (which returns it), avoiding a duplicate
+   full-range query per user.
 3. **Skip silently when there are no reviewed expenses** in the range
    (return `(false, nil)`). A weekly "please run /review" nudge would be
    noise; the recap only appears when the user has reflection data.
-4. Analyze: `analyzeExpenseHabit(len(expenses), reviewed, loc, label)`
+4. Analyze: `analyzeExpenseHabit(totalCount, reviewed, loc, label)`
    (`internal/bot/habit_analyzer.go:62`) with a previous-week label in the
    same style as the weekly summary header, e.g.
    `prevStart.Format("Jan 2") + " to " + prevEnd.AddDate(0,0,-1).Format("Jan 2, 2006")`.

--- a/internal/bot/date_range_rapid_test.go
+++ b/internal/bot/date_range_rapid_test.go
@@ -197,6 +197,33 @@ func TestHegelGetWeekDateRangeAtInvariants(t *testing.T) {
 	})
 }
 
+// TestHegelGetPreviousWeekRangeAtInvariants asserts the previous-week
+// contract used by the weekly report and habit recap: a [start, end) window
+// exactly one week wide, starting on a Monday at midnight, that ends
+// precisely where getWeekDateRangeAt says the current week begins.
+func TestHegelGetPreviousWeekRangeAtInvariants(t *testing.T) {
+	t.Parallel()
+	hegel.Test(t, func(ht *hegel.T) {
+		cur := hegel.Draw(ht, hegelTimeInLocationGen())
+		start, end := getPreviousWeekRangeAt(cur)
+
+		require.Equal(ht, time.Monday, start.Weekday(), "start=%s", start)
+		require.Equal(ht, 0, start.Hour())
+		require.Equal(ht, 0, start.Minute())
+		require.Equal(ht, 0, start.Second())
+		require.Equal(ht, 0, start.Nanosecond())
+		require.Equal(ht, start.AddDate(0, 0, 7), end)
+
+		currentWeekStart, _ := getWeekDateRangeAt(cur)
+		require.Equal(ht, currentWeekStart, end,
+			"previous week must end where the current week begins")
+		require.True(ht, start.Before(cur), "cur=%s start=%s", cur, start)
+		require.False(ht, cur.Before(end), "cur=%s end=%s", cur, end)
+		require.Equal(ht, cur.Location(), start.Location())
+		require.Equal(ht, cur.Location(), end.Location())
+	})
+}
+
 // TestHegelGetMonthDateRangeAtInvariants is the Hegel equivalent of the
 // month-range contract.
 func TestHegelGetMonthDateRangeAtInvariants(t *testing.T) {

--- a/internal/bot/habit_analyzer_hegel_test.go
+++ b/internal/bot/habit_analyzer_hegel_test.go
@@ -7,8 +7,9 @@ import (
 
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/require"
-	appmodels "gitlab.com/yelinaung/expense-bot/internal/models"
 	"hegel.dev/go/hegel"
+
+	appmodels "gitlab.com/yelinaung/expense-bot/internal/models"
 )
 
 // hegelReviewedExpenseGen draws an expense in the shape

--- a/internal/bot/habit_analyzer_hegel_test.go
+++ b/internal/bot/habit_analyzer_hegel_test.go
@@ -1,0 +1,230 @@
+package bot
+
+import (
+	"slices"
+	"strconv"
+	"testing"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/require"
+	appmodels "gitlab.com/yelinaung/expense-bot/internal/models"
+	"hegel.dev/go/hegel"
+)
+
+// hegelReviewedExpenseGen draws an expense in the shape
+// GetReviewedByUserIDAndDateRange feeds to analyzeExpenseHabit. WorthIt is
+// drawn as nil/true/false because the analyzer must skip nil entries, and
+// SpendDriver covers nil, empty, and known drivers because the analyzer
+// only counts non-empty ones.
+func hegelReviewedExpenseGen() hegel.Generator[appmodels.Expense] {
+	return hegel.Composite(func(tc hegel.TestCase) appmodels.Expense {
+		expense := appmodels.Expense{
+			Amount:    hegel.Draw(tc, hegelAmountGen()),
+			Currency:  hegel.Draw(tc, hegel.SampledFrom(expenseTestCurrencies)),
+			Category:  hegel.Draw(tc, hegelCategoryOrNilGen()),
+			WorthIt:   hegel.Draw(tc, hegel.Optional(hegel.Booleans())),
+			CreatedAt: hegel.Draw(tc, hegelTimeInLocationGen()),
+		}
+		switch hegel.Draw(tc, hegel.Integers(0, 2)) {
+		case 0:
+			// No driver recorded.
+		case 1:
+			empty := ""
+			expense.SpendDriver = &empty
+		default:
+			idx := hegel.Draw(tc, hegel.Integers(0, len(spendingDrivers)-1))
+			driver := string(spendingDrivers[idx])
+			expense.SpendDriver = &driver
+		}
+		return expense
+	})
+}
+
+// hegelReviewedExpensesGen draws a slice of reviewed expenses. The size is
+// drawn separately so large slices are actually produced.
+func hegelReviewedExpensesGen() hegel.Generator[[]appmodels.Expense] {
+	return hegel.Composite(func(tc hegel.TestCase) []appmodels.Expense {
+		n := hegel.Draw(tc, hegel.Integers(0, 60))
+		return hegel.Draw(tc, hegel.Lists(hegelReviewedExpenseGen()).MinSize(n))
+	})
+}
+
+// requireSameCurrencyTotals asserts two currency→amount maps hold the same
+// keys with decimal-equal values, ignoring internal decimal representation.
+func requireSameCurrencyTotals(t require.TestingT, want, got map[string]decimal.Decimal) {
+	require.Len(t, got, len(want))
+	for currency, amount := range want {
+		require.True(t, amount.Equal(got[currency]),
+			"currency %s: want %s, got %s", currency, amount, got[currency])
+	}
+}
+
+// TestHegelAnalyzeExpenseHabitCountConservation asserts the summary's counts
+// are conserved: every expense with a non-nil WorthIt is counted exactly
+// once as either worth-it or not-worth-it, and TotalCount/PeriodLabel pass
+// through unchanged.
+func TestHegelAnalyzeExpenseHabitCountConservation(t *testing.T) {
+	t.Parallel()
+	hegel.Test(t, func(ht *hegel.T) {
+		expenses := hegel.Draw(ht, hegelReviewedExpensesGen())
+		extra := hegel.Draw(ht, hegel.Integers(0, 50))
+		totalCount := len(expenses) + extra
+		loc := hegel.Draw(ht, hegelLocationGen())
+
+		summary := analyzeExpenseHabit(totalCount, expenses, loc, "label")
+
+		wantReviewed, wantWorth := 0, 0
+		for i := range expenses {
+			if expenses[i].WorthIt == nil {
+				continue
+			}
+			wantReviewed++
+			if *expenses[i].WorthIt {
+				wantWorth++
+			}
+		}
+		require.Equal(ht, "label", summary.PeriodLabel)
+		require.Equal(ht, totalCount, summary.TotalCount)
+		require.Equal(ht, wantReviewed, summary.ReviewedCount)
+		require.Equal(ht, wantWorth, summary.WorthItCount)
+		require.Equal(ht, wantReviewed-wantWorth, summary.NotWorthItCount)
+	})
+}
+
+// TestHegelAnalyzeExpenseHabitCurrencyTotalsOracle asserts the per-currency
+// worth-it and not-worth-it totals against an independently computed oracle,
+// and that they reconcile with sumExpenseAmountsByCurrency over the reviewed
+// subset — the helper the weekly report uses for its own totals.
+func TestHegelAnalyzeExpenseHabitCurrencyTotalsOracle(t *testing.T) {
+	t.Parallel()
+	hegel.Test(t, func(ht *hegel.T) {
+		expenses := hegel.Draw(ht, hegelReviewedExpensesGen())
+		loc := hegel.Draw(ht, hegelLocationGen())
+
+		summary := analyzeExpenseHabit(len(expenses), expenses, loc, "label")
+
+		wantWorth := map[string]decimal.Decimal{}
+		wantNotWorth := map[string]decimal.Decimal{}
+		var reviewed []appmodels.Expense
+		for i := range expenses {
+			e := expenses[i]
+			if e.WorthIt == nil {
+				continue
+			}
+			reviewed = append(reviewed, e)
+			if *e.WorthIt {
+				wantWorth[e.Currency] = wantWorth[e.Currency].Add(e.Amount)
+			} else {
+				wantNotWorth[e.Currency] = wantNotWorth[e.Currency].Add(e.Amount)
+			}
+		}
+		requireSameCurrencyTotals(ht, wantWorth, summary.WorthItByCurrency)
+		requireSameCurrencyTotals(ht, wantNotWorth, summary.NotWorthItByCurrency)
+
+		// Worth-it plus not-worth-it must reconcile with the weekly
+		// report's own aggregation of the reviewed subset.
+		combined := map[string]decimal.Decimal{}
+		for currency, amount := range summary.WorthItByCurrency {
+			combined[currency] = combined[currency].Add(amount)
+		}
+		for currency, amount := range summary.NotWorthItByCurrency {
+			combined[currency] = combined[currency].Add(amount)
+		}
+		requireSameCurrencyTotals(ht, sumExpenseAmountsByCurrency(reviewed), combined)
+	})
+}
+
+// TestHegelAnalyzeExpenseHabitOrderInvariance asserts the summary does not
+// depend on input slice order. The analyzer aggregates through Go maps and
+// breaks ties explicitly (alphabetical, weekday order), so a reversed input
+// must produce an identical summary; a violation would mean nondeterministic
+// map-iteration order leaks into the result.
+func TestHegelAnalyzeExpenseHabitOrderInvariance(t *testing.T) {
+	t.Parallel()
+	hegel.Test(t, func(ht *hegel.T) {
+		expenses := hegel.Draw(ht, hegelReviewedExpensesGen())
+		loc := hegel.Draw(ht, hegelLocationGen())
+
+		reversed := slices.Clone(expenses)
+		slices.Reverse(reversed)
+
+		got := analyzeExpenseHabit(len(expenses), expenses, loc, "label")
+		gotReversed := analyzeExpenseHabit(len(expenses), reversed, loc, "label")
+
+		require.Equal(ht, got.ReviewedCount, gotReversed.ReviewedCount)
+		require.Equal(ht, got.WorthItCount, gotReversed.WorthItCount)
+		require.Equal(ht, got.NotWorthItCount, gotReversed.NotWorthItCount)
+		require.Equal(ht, got.TopDriver, gotReversed.TopDriver)
+		require.Equal(ht, got.BestValueCategory, gotReversed.BestValueCategory)
+		require.Equal(ht, got.MostRegrettedCategory, gotReversed.MostRegrettedCategory)
+		require.Equal(ht, got.HasBusiestNotWorthItWeekday, gotReversed.HasBusiestNotWorthItWeekday)
+		require.Equal(ht, got.BusiestNotWorthItWeekday, gotReversed.BusiestNotWorthItWeekday)
+		requireSameCurrencyTotals(ht, got.WorthItByCurrency, gotReversed.WorthItByCurrency)
+		requireSameCurrencyTotals(ht, got.NotWorthItByCurrency, gotReversed.NotWorthItByCurrency)
+	})
+}
+
+// TestHegelAnalyzeExpenseHabitBusiestWeekdayIffNotWorthIt asserts the
+// weekday-pattern flag is set exactly when at least one not-worth-it expense
+// exists, since only not-worth-it expenses feed the weekday counts.
+func TestHegelAnalyzeExpenseHabitBusiestWeekdayIffNotWorthIt(t *testing.T) {
+	t.Parallel()
+	hegel.Test(t, func(ht *hegel.T) {
+		expenses := hegel.Draw(ht, hegelReviewedExpensesGen())
+		loc := hegel.Draw(ht, hegelLocationGen())
+
+		summary := analyzeExpenseHabit(len(expenses), expenses, loc, "label")
+
+		require.Equal(ht, summary.NotWorthItCount > 0, summary.HasBusiestNotWorthItWeekday)
+	})
+}
+
+// TestHegelAnalyzeExpenseHabitMinSampleGuard asserts the documented
+// minimum-sample rule: a category may only be named best-value or
+// most-regretted when it has at least minCategoryReflectionSample reviewed
+// expenses.
+func TestHegelAnalyzeExpenseHabitMinSampleGuard(t *testing.T) {
+	t.Parallel()
+	hegel.Test(t, func(ht *hegel.T) {
+		expenses := hegel.Draw(ht, hegelReviewedExpensesGen())
+		loc := hegel.Draw(ht, hegelLocationGen())
+
+		summary := analyzeExpenseHabit(len(expenses), expenses, loc, "label")
+
+		reviewedPerCategory := map[string]int{}
+		for i := range expenses {
+			if expenses[i].WorthIt == nil {
+				continue
+			}
+			reviewedPerCategory[habitCategoryName(&expenses[i])]++
+		}
+		for _, category := range []string{summary.BestValueCategory, summary.MostRegrettedCategory} {
+			if category == "" {
+				continue
+			}
+			require.GreaterOrEqual(ht, reviewedPerCategory[category], minCategoryReflectionSample,
+				"category %q named with fewer than %d reviewed expenses",
+				category, minCategoryReflectionSample)
+		}
+	})
+}
+
+// TestHegelFormatHabitSummaryRobustness asserts the recap renderer never
+// panics on analyzer output for arbitrary expenses and Unicode period
+// labels, always reports the counts, and HTML-escapes the label. Both
+// /habit and the weekly habit recap render through this function.
+func TestHegelFormatHabitSummaryRobustness(t *testing.T) {
+	t.Parallel()
+	hegel.Test(t, func(ht *hegel.T) {
+		expenses := hegel.Draw(ht, hegelReviewedExpensesGen())
+		loc := hegel.Draw(ht, hegelLocationGen())
+		label := hegel.Draw(ht, hegel.Text().MaxSize(50))
+
+		summary := analyzeExpenseHabit(len(expenses), expenses, loc, label)
+		out := formatHabitSummary(&summary)
+
+		require.Contains(ht, out, escapeHTML(label))
+		require.Contains(ht, out,
+			"Reviewed: "+strconv.Itoa(summary.ReviewedCount)+"/"+strconv.Itoa(summary.TotalCount))
+	})
+}

--- a/internal/bot/handlers_chart.go
+++ b/internal/bot/handlers_chart.go
@@ -99,7 +99,8 @@ func (b *Bot) handleChartCore(ctx context.Context, tg TelegramAPI, update *model
 	}
 
 	// Generate chart
-	_, genSpan := telemetry.StartSpan(ctx, "chart.generate",
+	_, genSpan := telemetry.StartSpan(
+		ctx, "chart.generate",
 		attribute.String("chart.period", period),
 		attribute.Int("chart.expense_count", len(expenses)),
 	)
@@ -142,7 +143,8 @@ func (b *Bot) handleChartCore(ctx context.Context, tg TelegramAPI, update *model
 	caption := fmt.Sprintf("📊 <b>%s</b>\n\nTotal: $%s SGD\nCount: %d expenses\nPeriod: %s",
 		title, total.StringFixed(2), len(expenses), periodRange)
 
-	sendCtx, sendSpan := telemetry.StartSpan(ctx, "telegram.send_document",
+	sendCtx, sendSpan := telemetry.StartSpan(
+		ctx, "telegram.send_document",
 		attribute.Int("document.size_bytes", len(chartData)),
 		attribute.String("document.filename", filename),
 	)

--- a/internal/bot/weekly_report.go
+++ b/internal/bot/weekly_report.go
@@ -24,6 +24,12 @@ const (
 	WeeklyReportCheckInterval = 30 * time.Minute
 	// WeeklyReportTimeout is the maximum time a single check can take.
 	WeeklyReportTimeout = 2 * time.Minute
+
+	// backgroundJobStatusOK and backgroundJobStatusError are the allowed
+	// values for the background job metrics' status attribute. Keep them
+	// centralized so dashboards never see a split timeseries from a typo.
+	backgroundJobStatusOK    = "ok"
+	backgroundJobStatusError = "error"
 )
 
 // startWeeklyReportLoop runs a periodic loop that sends weekly expense
@@ -85,7 +91,7 @@ func (b *Bot) checkAndSendWeeklyReports(ctx context.Context, sent map[int64]stri
 	)
 	if err != nil {
 		logger.Log.Error().Err(err).Msg("Failed to fetch users for weekly report")
-		b.recordWeeklyReportMetrics(ctx, start, "error")
+		b.recordWeeklyReportMetrics(ctx, start, backgroundJobStatusError)
 		return
 	}
 
@@ -93,7 +99,7 @@ func (b *Bot) checkAndSendWeeklyReports(ctx context.Context, sent map[int64]stri
 		b.processWeeklyReportUser(checkCtx, &users[i], sent, now)
 	}
 
-	b.recordWeeklyReportMetrics(ctx, start, "ok")
+	b.recordWeeklyReportMetrics(ctx, start, backgroundJobStatusOK)
 }
 
 // pruneWeeklyReportSent removes entries older than 2 weeks from the sent map.
@@ -130,14 +136,14 @@ func (b *Bot) processWeeklyReportUser(
 		return
 	}
 
-	sentOK, err := b.sendWeeklySummary(ctx, user, userNow)
+	expenseCount, err := b.sendWeeklySummary(ctx, user, userNow)
 	if err != nil {
 		logger.Log.Warn().Err(err).
 			Str("user_hash", logger.HashUserID(user.ID)).
 			Msg("Failed to send weekly report")
 		return
 	}
-	if !sentOK {
+	if expenseCount == 0 {
 		logger.Log.Debug().
 			Str("user_hash", logger.HashUserID(user.ID)).
 			Msg("No weekly expenses; skipping report")
@@ -151,7 +157,7 @@ func (b *Bot) processWeeklyReportUser(
 		Msg("Sent weekly report")
 
 	if b.cfg.WeeklyHabitRecapEnabled {
-		b.sendWeeklyHabitRecapForUser(ctx, user, userNow)
+		b.sendWeeklyHabitRecapForUser(ctx, user, userNow, expenseCount)
 	}
 }
 
@@ -162,13 +168,15 @@ func (b *Bot) sendWeeklyHabitRecapForUser(
 	ctx context.Context,
 	user *appmodels.User,
 	userNow time.Time,
+	totalCount int,
 ) {
-	recapSent, err := b.sendWeeklyHabitRecap(ctx, user, userNow)
+	start := time.Now()
+	recapSent, err := b.sendWeeklyHabitRecap(ctx, user, userNow, totalCount)
 	if err != nil {
 		logger.Log.Warn().Err(err).
 			Str("user_hash", logger.HashUserID(user.ID)).
 			Msg("Failed to send weekly habit recap")
-		b.recordHabitRecapMetric(ctx, "error")
+		b.recordHabitRecapMetrics(ctx, start, backgroundJobStatusError)
 		return
 	}
 	if !recapSent {
@@ -177,15 +185,15 @@ func (b *Bot) sendWeeklyHabitRecapForUser(
 			Msg("No reviewed expenses; skipping weekly habit recap")
 		return
 	}
-	b.recordHabitRecapMetric(ctx, "ok")
+	b.recordHabitRecapMetrics(ctx, start, backgroundJobStatusOK)
 	logger.Log.Debug().
 		Str("user_hash", logger.HashUserID(user.ID)).
 		Msg("Sent weekly habit recap")
 }
 
-// recordHabitRecapMetric records a background job run for the weekly
+// recordHabitRecapMetrics records background job metrics for a weekly
 // habit recap send attempt.
-func (b *Bot) recordHabitRecapMetric(ctx context.Context, status string) {
+func (b *Bot) recordHabitRecapMetrics(ctx context.Context, start time.Time, status string) {
 	if b.metrics == nil {
 		return
 	}
@@ -193,6 +201,8 @@ func (b *Bot) recordHabitRecapMetric(ctx context.Context, status string) {
 		attribute.String("job", "weekly_habit_recap"),
 		attribute.String("status", status),
 	))
+	b.metrics.BackgroundJobDuration.Record(ctx, time.Since(start).Seconds(),
+		otelmetric.WithAttributes(attribute.String("job", "weekly_habit_recap")))
 }
 
 // recordWeeklyReportMetrics records background job metrics for the
@@ -209,23 +219,23 @@ func (b *Bot) recordWeeklyReportMetrics(ctx context.Context, start time.Time, st
 		otelmetric.WithAttributes(attribute.String("job", "weekly_report")))
 }
 
-// sendWeeklySummary sends a weekly expense summary to the user.
-// The returned bool indicates whether a message was actually sent.
-// When there are no expenses, (false, nil) is returned.
+// sendWeeklySummary sends a weekly expense summary to the user. It
+// returns the number of expenses in the previous week; a message is
+// only sent when the count is non-zero, so 0 means nothing was sent.
 func (b *Bot) sendWeeklySummary(
 	ctx context.Context,
 	user *appmodels.User,
 	userNow time.Time,
-) (bool, error) {
+) (int, error) {
 	startOfWeek, endOfWeek := getPreviousWeekRangeAt(userNow)
 
 	expenses, err := b.expenseRepo.GetByUserIDAndDateRange(ctx, user.ID, startOfWeek, endOfWeek)
 	if err != nil {
-		return false, fmt.Errorf("failed to fetch weekly expenses: %w", err)
+		return 0, fmt.Errorf("failed to fetch weekly expenses: %w", err)
 	}
 
 	if len(expenses) == 0 {
-		return false, nil
+		return 0, nil
 	}
 
 	totalsByCurrency := sumExpenseAmountsByCurrency(expenses)
@@ -266,26 +276,24 @@ func (b *Bot) sendWeeklySummary(
 		ParseMode: tgmodels.ParseModeHTML,
 	})
 	if err != nil {
-		return false, fmt.Errorf("failed to send weekly summary: %w", err)
+		return 0, fmt.Errorf("failed to send weekly summary: %w", err)
 	}
-	return true, nil
+	return len(expenses), nil
 }
 
 // sendWeeklyHabitRecap sends the previous week's spending reflection
-// recap to the user. The returned bool indicates whether a message was
+// recap to the user. totalCount is the previous week's expense count
+// already fetched by sendWeeklySummary, so the recap only queries the
+// reviewed subset. The returned bool indicates whether a message was
 // actually sent. When the user has no reviewed expenses in the previous
 // week, (false, nil) is returned.
 func (b *Bot) sendWeeklyHabitRecap(
 	ctx context.Context,
 	user *appmodels.User,
 	userNow time.Time,
+	totalCount int,
 ) (bool, error) {
 	startOfWeek, endOfWeek := getPreviousWeekRangeAt(userNow)
-
-	expenses, err := b.expenseRepo.GetByUserIDAndDateRange(ctx, user.ID, startOfWeek, endOfWeek)
-	if err != nil {
-		return false, fmt.Errorf("failed to fetch expenses for habit recap: %w", err)
-	}
 
 	reviewed, err := b.expenseRepo.GetReviewedByUserIDAndDateRange(ctx, user.ID, startOfWeek, endOfWeek)
 	if err != nil {
@@ -299,7 +307,7 @@ func (b *Bot) sendWeeklyHabitRecap(
 	label := fmt.Sprintf("%s to %s",
 		startOfWeek.Format("Jan 2"),
 		endOfWeek.AddDate(0, 0, -1).Format("Jan 2, 2006"))
-	summary := analyzeExpenseHabit(len(expenses), reviewed, loc, label)
+	summary := analyzeExpenseHabit(totalCount, reviewed, loc, label)
 
 	_, err = b.messageSender.SendMessage(ctx, &tgbot.SendMessageParams{
 		ChatID:    user.ID,

--- a/internal/bot/weekly_report.go
+++ b/internal/bot/weekly_report.go
@@ -149,6 +149,50 @@ func (b *Bot) processWeeklyReportUser(
 		Str("user_hash", logger.HashUserID(user.ID)).
 		Str("timezone", loc.String()).
 		Msg("Sent weekly report")
+
+	if b.cfg.WeeklyHabitRecapEnabled {
+		b.sendWeeklyHabitRecapForUser(ctx, user, userNow)
+	}
+}
+
+// sendWeeklyHabitRecapForUser sends the habit recap best-effort after
+// the weekly summary. Failures are logged and do not affect the sent
+// map, so the weekly summary is never re-sent because of a recap error.
+func (b *Bot) sendWeeklyHabitRecapForUser(
+	ctx context.Context,
+	user *appmodels.User,
+	userNow time.Time,
+) {
+	recapSent, err := b.sendWeeklyHabitRecap(ctx, user, userNow)
+	if err != nil {
+		logger.Log.Warn().Err(err).
+			Str("user_hash", logger.HashUserID(user.ID)).
+			Msg("Failed to send weekly habit recap")
+		b.recordHabitRecapMetric(ctx, "error")
+		return
+	}
+	if !recapSent {
+		logger.Log.Debug().
+			Str("user_hash", logger.HashUserID(user.ID)).
+			Msg("No reviewed expenses; skipping weekly habit recap")
+		return
+	}
+	b.recordHabitRecapMetric(ctx, "ok")
+	logger.Log.Debug().
+		Str("user_hash", logger.HashUserID(user.ID)).
+		Msg("Sent weekly habit recap")
+}
+
+// recordHabitRecapMetric records a background job run for the weekly
+// habit recap send attempt.
+func (b *Bot) recordHabitRecapMetric(ctx context.Context, status string) {
+	if b.metrics == nil {
+		return
+	}
+	b.metrics.BackgroundJobRuns.Add(ctx, 1, otelmetric.WithAttributes(
+		attribute.String("job", "weekly_habit_recap"),
+		attribute.String("status", status),
+	))
 }
 
 // recordWeeklyReportMetrics records background job metrics for the
@@ -223,6 +267,47 @@ func (b *Bot) sendWeeklySummary(
 	})
 	if err != nil {
 		return false, fmt.Errorf("failed to send weekly summary: %w", err)
+	}
+	return true, nil
+}
+
+// sendWeeklyHabitRecap sends the previous week's spending reflection
+// recap to the user. The returned bool indicates whether a message was
+// actually sent. When the user has no reviewed expenses in the previous
+// week, (false, nil) is returned.
+func (b *Bot) sendWeeklyHabitRecap(
+	ctx context.Context,
+	user *appmodels.User,
+	userNow time.Time,
+) (bool, error) {
+	startOfWeek, endOfWeek := getPreviousWeekRangeAt(userNow)
+
+	expenses, err := b.expenseRepo.GetByUserIDAndDateRange(ctx, user.ID, startOfWeek, endOfWeek)
+	if err != nil {
+		return false, fmt.Errorf("failed to fetch expenses for habit recap: %w", err)
+	}
+
+	reviewed, err := b.expenseRepo.GetReviewedByUserIDAndDateRange(ctx, user.ID, startOfWeek, endOfWeek)
+	if err != nil {
+		return false, fmt.Errorf("failed to fetch reviewed expenses for habit recap: %w", err)
+	}
+	if len(reviewed) == 0 {
+		return false, nil
+	}
+
+	loc := b.userLocation(user.Timezone)
+	label := fmt.Sprintf("%s to %s",
+		startOfWeek.Format("Jan 2"),
+		endOfWeek.AddDate(0, 0, -1).Format("Jan 2, 2006"))
+	summary := analyzeExpenseHabit(len(expenses), reviewed, loc, label)
+
+	_, err = b.messageSender.SendMessage(ctx, &tgbot.SendMessageParams{
+		ChatID:    user.ID,
+		Text:      formatHabitSummary(&summary),
+		ParseMode: tgmodels.ParseModeHTML,
+	})
+	if err != nil {
+		return false, fmt.Errorf("failed to send weekly habit recap: %w", err)
 	}
 	return true, nil
 }

--- a/internal/bot/weekly_report_test.go
+++ b/internal/bot/weekly_report_test.go
@@ -8,9 +8,15 @@ import (
 
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric/noop"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
 	"gitlab.com/yelinaung/expense-bot/internal/bot/mocks"
 	"gitlab.com/yelinaung/expense-bot/internal/models"
+	"gitlab.com/yelinaung/expense-bot/internal/telemetry"
 )
 
 func TestCheckAndSendWeeklyReports(t *testing.T) {
@@ -424,6 +430,150 @@ func TestCheckAndSendWeeklyReports(t *testing.T) {
 		require.Contains(t, msg.Text, "Weekly Expenses")
 		require.Contains(t, msg.Text, "Tea")
 	})
+
+	t.Run("sends habit recap after weekly summary when recap enabled", func(t *testing.T) {
+		ctx := context.Background()
+		pool := testDB(ctx, t)
+		b := setupTestBot(t, pool)
+		b.displayLocation = loc
+		mockBot := mocks.NewMockBot()
+		b.messageSender = mockBot
+		b.cfg.WeeklyReportEnabled = true
+		b.cfg.WeeklyHabitRecapEnabled = true
+		b.cfg.WeeklyReportDay = time.Monday
+		b.cfg.WeeklyReportHour = 9
+		b.cfg.WhitelistedUserIDs = []int64{4104}
+
+		err := b.userRepo.UpsertUser(ctx, &models.User{
+			ID:        4104,
+			Username:  "recapuser",
+			FirstName: "Rita",
+		})
+		require.NoError(t, err)
+		err = b.userRepo.UpdateTimezone(ctx, 4104, "Etc/GMT-8")
+		require.NoError(t, err)
+
+		// Create a reviewed expense in the previous week (Apr 27 - May 3).
+		prevMonday := time.Date(2026, 4, 27, 10, 0, 0, 0, loc)
+		expense := &models.Expense{
+			UserID:      4104,
+			Amount:      decimal.NewFromFloat(12.00),
+			Currency:    "SGD",
+			Description: "Taxi",
+			Status:      models.ExpenseStatusConfirmed,
+		}
+		err = b.expenseRepo.Create(ctx, expense)
+		require.NoError(t, err)
+		_, err = b.db.Exec(ctx, testUpdateExpenseTimeSQL, prevMonday, expense.ID)
+		require.NoError(t, err)
+		worthIt := true
+		err = b.expenseRepo.UpdateReflection(ctx, expense.ID, 4104, &worthIt, "Convenience")
+		require.NoError(t, err)
+
+		sent := make(map[int64]string)
+		b.checkAndSendWeeklyReports(ctx, sent, monday9amUTC)
+
+		require.Equal(t, 2, mockBot.SentMessageCount(), "should send weekly summary and habit recap")
+		require.Contains(t, mockBot.SentMessages[0].Text, "Weekly Expenses")
+		recap := mockBot.SentMessages[1]
+		require.Equal(t, int64(4104), recap.ChatID)
+		require.Contains(t, recap.Text, "Spending Reflection")
+		require.Contains(t, recap.Text, "Apr 27 to May 3, 2026")
+		require.Contains(t, recap.Text, "Reviewed: 1/1")
+		require.Contains(t, recap.Text, "Worth it: 1")
+		require.Contains(t, recap.Text, "Convenience")
+		require.Equal(t, "2026-04-27", sent[4104])
+	})
+
+	t.Run("skips habit recap when no reviewed expenses", func(t *testing.T) {
+		ctx := context.Background()
+		pool := testDB(ctx, t)
+		b := setupTestBot(t, pool)
+		b.displayLocation = loc
+		mockBot := mocks.NewMockBot()
+		b.messageSender = mockBot
+		b.cfg.WeeklyReportEnabled = true
+		b.cfg.WeeklyHabitRecapEnabled = true
+		b.cfg.WeeklyReportDay = time.Monday
+		b.cfg.WeeklyReportHour = 9
+		b.cfg.WhitelistedUserIDs = []int64{4105}
+
+		err := b.userRepo.UpsertUser(ctx, &models.User{
+			ID:        4105,
+			Username:  "unreviewed",
+			FirstName: "Uma",
+		})
+		require.NoError(t, err)
+		err = b.userRepo.UpdateTimezone(ctx, 4105, "Etc/GMT-8")
+		require.NoError(t, err)
+
+		// Expense in the previous week, but never reviewed.
+		prevMonday := time.Date(2026, 4, 27, 10, 0, 0, 0, loc)
+		expense := &models.Expense{
+			UserID:      4105,
+			Amount:      decimal.NewFromFloat(8.00),
+			Currency:    "SGD",
+			Description: "Snack",
+			Status:      models.ExpenseStatusConfirmed,
+		}
+		err = b.expenseRepo.Create(ctx, expense)
+		require.NoError(t, err)
+		_, err = b.db.Exec(ctx, testUpdateExpenseTimeSQL, prevMonday, expense.ID)
+		require.NoError(t, err)
+
+		sent := make(map[int64]string)
+		b.checkAndSendWeeklyReports(ctx, sent, monday9amUTC)
+
+		require.Equal(t, 1, mockBot.SentMessageCount(), "should send only the weekly summary")
+		require.Contains(t, mockBot.LastSentMessage().Text, "Weekly Expenses")
+		require.Equal(t, "2026-04-27", sent[4105])
+	})
+
+	t.Run("does not send habit recap when recap disabled", func(t *testing.T) {
+		ctx := context.Background()
+		pool := testDB(ctx, t)
+		b := setupTestBot(t, pool)
+		b.displayLocation = loc
+		mockBot := mocks.NewMockBot()
+		b.messageSender = mockBot
+		b.cfg.WeeklyReportEnabled = true
+		b.cfg.WeeklyHabitRecapEnabled = false
+		b.cfg.WeeklyReportDay = time.Monday
+		b.cfg.WeeklyReportHour = 9
+		b.cfg.WhitelistedUserIDs = []int64{4106}
+
+		err := b.userRepo.UpsertUser(ctx, &models.User{
+			ID:        4106,
+			Username:  "recapoff",
+			FirstName: "Omar",
+		})
+		require.NoError(t, err)
+		err = b.userRepo.UpdateTimezone(ctx, 4106, "Etc/GMT-8")
+		require.NoError(t, err)
+
+		// A reviewed expense exists, but the recap flag is off.
+		prevMonday := time.Date(2026, 4, 27, 10, 0, 0, 0, loc)
+		expense := &models.Expense{
+			UserID:      4106,
+			Amount:      decimal.NewFromFloat(15.00),
+			Currency:    "SGD",
+			Description: "Book",
+			Status:      models.ExpenseStatusConfirmed,
+		}
+		err = b.expenseRepo.Create(ctx, expense)
+		require.NoError(t, err)
+		_, err = b.db.Exec(ctx, testUpdateExpenseTimeSQL, prevMonday, expense.ID)
+		require.NoError(t, err)
+		worthIt := false
+		err = b.expenseRepo.UpdateReflection(ctx, expense.ID, 4106, &worthIt, "Impulse")
+		require.NoError(t, err)
+
+		sent := make(map[int64]string)
+		b.checkAndSendWeeklyReports(ctx, sent, monday9amUTC)
+
+		require.Equal(t, 1, mockBot.SentMessageCount(), "should send only the weekly summary")
+		require.Contains(t, mockBot.LastSentMessage().Text, "Weekly Expenses")
+	})
 }
 
 func TestGetPreviousWeekRangeAt(t *testing.T) {
@@ -533,6 +683,199 @@ func TestSendWeeklySummary_FetchError(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to fetch weekly expenses")
 	require.False(t, sent)
+}
+
+func TestSendWeeklyHabitRecap_FetchError(t *testing.T) {
+	ctx := context.Background()
+	pool := testDB(ctx, t)
+	b := setupTestBot(t, pool)
+
+	canceledCtx, cancel := context.WithCancel(ctx)
+	cancel()
+
+	sent, err := b.sendWeeklyHabitRecap(
+		canceledCtx,
+		&models.User{ID: 5004, FirstName: "Err"},
+		time.Now(),
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to fetch expenses for habit recap")
+	require.False(t, sent)
+}
+
+// createReviewedExpense inserts a confirmed worth-it expense for the user,
+// backdates it to createdAt, and marks it reviewed.
+func createReviewedExpense(
+	ctx context.Context,
+	t *testing.T,
+	b *Bot,
+	userID int64,
+	createdAt time.Time,
+) {
+	t.Helper()
+	expense := &models.Expense{
+		UserID:      userID,
+		Amount:      decimal.NewFromFloat(9.50),
+		Currency:    "SGD",
+		Description: "Coffee",
+		Status:      models.ExpenseStatusConfirmed,
+	}
+	err := b.expenseRepo.Create(ctx, expense)
+	require.NoError(t, err)
+	_, err = b.db.Exec(ctx, testUpdateExpenseTimeSQL, createdAt, expense.ID)
+	require.NoError(t, err)
+	worthIt := true
+	err = b.expenseRepo.UpdateReflection(ctx, expense.ID, userID, &worthIt, "Ritual")
+	require.NoError(t, err)
+}
+
+// habitRecapRunCount returns the recorded background.job.runs counter
+// value for the weekly_habit_recap job with the given status attribute.
+func habitRecapRunCount(rm metricdata.ResourceMetrics, status string) int64 {
+	for i := range rm.ScopeMetrics {
+		for j := range rm.ScopeMetrics[i].Metrics {
+			metric := rm.ScopeMetrics[i].Metrics[j]
+			if metric.Name != "background.job.runs" {
+				continue
+			}
+			sum, ok := metric.Data.(metricdata.Sum[int64])
+			if !ok {
+				return 0
+			}
+			for _, dp := range sum.DataPoints {
+				jobVal, _ := dp.Attributes.Value(attribute.Key("job"))
+				statusVal, _ := dp.Attributes.Value(attribute.Key("status"))
+				if jobVal.AsString() == "weekly_habit_recap" && statusVal.AsString() == status {
+					return dp.Value
+				}
+			}
+		}
+	}
+	return 0
+}
+
+func TestSendWeeklyHabitRecap_SendError(t *testing.T) {
+	ctx := context.Background()
+	pool := testDB(ctx, t)
+	b := setupTestBot(t, pool)
+
+	loc := time.FixedZone("GMT+8", 8*60*60)
+	b.displayLocation = loc
+	mockBot := mocks.NewMockBot()
+	mockBot.SendMessageError = errors.New("user blocked bot")
+	b.messageSender = mockBot
+
+	err := b.userRepo.UpsertUser(ctx, &models.User{
+		ID:        5005,
+		Username:  "recapsenderr",
+		FirstName: "Sena",
+	})
+	require.NoError(t, err)
+
+	userNow := time.Date(2026, 5, 4, 9, 0, 0, 0, loc)
+	createReviewedExpense(ctx, t, b, 5005, time.Date(2026, 4, 28, 10, 0, 0, 0, loc))
+
+	sent, err := b.sendWeeklyHabitRecap(ctx, &models.User{ID: 5005}, userNow)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to send weekly habit recap")
+	require.False(t, sent)
+}
+
+func TestSendWeeklyHabitRecapForUser_Metrics(t *testing.T) {
+	loc := time.FixedZone("GMT+8", 8*60*60)
+	userNow := time.Date(2026, 5, 4, 9, 0, 0, 0, loc)
+	prevWeekDay := time.Date(2026, 4, 28, 10, 0, 0, 0, loc)
+
+	setupMetrics := func(t *testing.T, b *Bot) *sdkmetric.ManualReader {
+		t.Helper()
+		reader := sdkmetric.NewManualReader()
+		meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+		otel.SetMeterProvider(meterProvider)
+		t.Cleanup(func() {
+			otel.SetMeterProvider(noop.NewMeterProvider())
+			_ = meterProvider.Shutdown(context.Background())
+		})
+		metrics, err := telemetry.NewBotMetrics()
+		require.NoError(t, err)
+		b.metrics = metrics
+		return reader
+	}
+
+	t.Run("records ok metric on successful recap", func(t *testing.T) {
+		ctx := context.Background()
+		pool := testDB(ctx, t)
+		b := setupTestBot(t, pool)
+		b.displayLocation = loc
+		mockBot := mocks.NewMockBot()
+		b.messageSender = mockBot
+		reader := setupMetrics(t, b)
+
+		err := b.userRepo.UpsertUser(ctx, &models.User{
+			ID:        5006,
+			Username:  "recapmetricok",
+			FirstName: "Mel",
+		})
+		require.NoError(t, err)
+		createReviewedExpense(ctx, t, b, 5006, prevWeekDay)
+
+		b.sendWeeklyHabitRecapForUser(ctx, &models.User{ID: 5006}, userNow)
+
+		require.Equal(t, 1, mockBot.SentMessageCount())
+		var rm metricdata.ResourceMetrics
+		require.NoError(t, reader.Collect(ctx, &rm))
+		require.Equal(t, int64(1), habitRecapRunCount(rm, "ok"))
+	})
+
+	t.Run("records error metric on send failure", func(t *testing.T) {
+		ctx := context.Background()
+		pool := testDB(ctx, t)
+		b := setupTestBot(t, pool)
+		b.displayLocation = loc
+		mockBot := mocks.NewMockBot()
+		mockBot.SendMessageError = errors.New("user blocked bot")
+		b.messageSender = mockBot
+		reader := setupMetrics(t, b)
+
+		err := b.userRepo.UpsertUser(ctx, &models.User{
+			ID:        5007,
+			Username:  "recapmetricerr",
+			FirstName: "Mia",
+		})
+		require.NoError(t, err)
+		createReviewedExpense(ctx, t, b, 5007, prevWeekDay)
+
+		b.sendWeeklyHabitRecapForUser(ctx, &models.User{ID: 5007}, userNow)
+
+		require.Equal(t, 0, mockBot.SentMessageCount())
+		var rm metricdata.ResourceMetrics
+		require.NoError(t, reader.Collect(ctx, &rm))
+		require.Equal(t, int64(1), habitRecapRunCount(rm, "error"))
+	})
+
+	t.Run("records no metric when nothing to send", func(t *testing.T) {
+		ctx := context.Background()
+		pool := testDB(ctx, t)
+		b := setupTestBot(t, pool)
+		b.displayLocation = loc
+		mockBot := mocks.NewMockBot()
+		b.messageSender = mockBot
+		reader := setupMetrics(t, b)
+
+		err := b.userRepo.UpsertUser(ctx, &models.User{
+			ID:        5008,
+			Username:  "recapmetricskip",
+			FirstName: "Mo",
+		})
+		require.NoError(t, err)
+
+		b.sendWeeklyHabitRecapForUser(ctx, &models.User{ID: 5008}, userNow)
+
+		require.Equal(t, 0, mockBot.SentMessageCount())
+		var rm metricdata.ResourceMetrics
+		require.NoError(t, reader.Collect(ctx, &rm))
+		require.Equal(t, int64(0), habitRecapRunCount(rm, "ok"))
+		require.Equal(t, int64(0), habitRecapRunCount(rm, "error"))
+	})
 }
 
 func TestCheckAndSendWeeklyReports_FetchUsersError(t *testing.T) {

--- a/internal/bot/weekly_report_test.go
+++ b/internal/bot/weekly_report_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/metric/noop"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
@@ -675,14 +674,14 @@ func TestSendWeeklySummary_FetchError(t *testing.T) {
 	canceledCtx, cancel := context.WithCancel(ctx)
 	cancel()
 
-	sent, err := b.sendWeeklySummary(
+	count, err := b.sendWeeklySummary(
 		canceledCtx,
 		&models.User{ID: 5002, FirstName: "Err"},
 		time.Now(),
 	)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to fetch weekly expenses")
-	require.False(t, sent)
+	require.Zero(t, count)
 }
 
 func TestSendWeeklyHabitRecap_FetchError(t *testing.T) {
@@ -697,9 +696,10 @@ func TestSendWeeklyHabitRecap_FetchError(t *testing.T) {
 		canceledCtx,
 		&models.User{ID: 5004, FirstName: "Err"},
 		time.Now(),
+		1,
 	)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "failed to fetch expenses for habit recap")
+	require.Contains(t, err.Error(), "failed to fetch reviewed expenses for habit recap")
 	require.False(t, sent)
 }
 
@@ -775,7 +775,7 @@ func TestSendWeeklyHabitRecap_SendError(t *testing.T) {
 	userNow := time.Date(2026, 5, 4, 9, 0, 0, 0, loc)
 	createReviewedExpense(ctx, t, b, 5005, time.Date(2026, 4, 28, 10, 0, 0, 0, loc))
 
-	sent, err := b.sendWeeklyHabitRecap(ctx, &models.User{ID: 5005}, userNow)
+	sent, err := b.sendWeeklyHabitRecap(ctx, &models.User{ID: 5005}, userNow, 1)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to send weekly habit recap")
 	require.False(t, sent)
@@ -790,9 +790,10 @@ func TestSendWeeklyHabitRecapForUser_Metrics(t *testing.T) {
 		t.Helper()
 		reader := sdkmetric.NewManualReader()
 		meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+		prev := otel.GetMeterProvider()
 		otel.SetMeterProvider(meterProvider)
 		t.Cleanup(func() {
-			otel.SetMeterProvider(noop.NewMeterProvider())
+			otel.SetMeterProvider(prev)
 			_ = meterProvider.Shutdown(context.Background())
 		})
 		metrics, err := telemetry.NewBotMetrics()
@@ -818,7 +819,7 @@ func TestSendWeeklyHabitRecapForUser_Metrics(t *testing.T) {
 		require.NoError(t, err)
 		createReviewedExpense(ctx, t, b, 5006, prevWeekDay)
 
-		b.sendWeeklyHabitRecapForUser(ctx, &models.User{ID: 5006}, userNow)
+		b.sendWeeklyHabitRecapForUser(ctx, &models.User{ID: 5006}, userNow, 1)
 
 		require.Equal(t, 1, mockBot.SentMessageCount())
 		var rm metricdata.ResourceMetrics
@@ -844,7 +845,7 @@ func TestSendWeeklyHabitRecapForUser_Metrics(t *testing.T) {
 		require.NoError(t, err)
 		createReviewedExpense(ctx, t, b, 5007, prevWeekDay)
 
-		b.sendWeeklyHabitRecapForUser(ctx, &models.User{ID: 5007}, userNow)
+		b.sendWeeklyHabitRecapForUser(ctx, &models.User{ID: 5007}, userNow, 1)
 
 		require.Equal(t, 0, mockBot.SentMessageCount())
 		var rm metricdata.ResourceMetrics
@@ -868,7 +869,7 @@ func TestSendWeeklyHabitRecapForUser_Metrics(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		b.sendWeeklyHabitRecapForUser(ctx, &models.User{ID: 5008}, userNow)
+		b.sendWeeklyHabitRecapForUser(ctx, &models.User{ID: 5008}, userNow, 0)
 
 		require.Equal(t, 0, mockBot.SentMessageCount())
 		var rm metricdata.ResourceMetrics

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,6 +38,10 @@ type Config struct {
 	WeeklyReportEnabled bool
 	WeeklyReportDay     time.Weekday
 	WeeklyReportHour    int
+	// WeeklyHabitRecapEnabled sends the previous week's spending
+	// reflection recap together with the weekly report. It only takes
+	// effect when WeeklyReportEnabled is true.
+	WeeklyHabitRecapEnabled bool
 
 	// OpenTelemetry configuration.
 	OTelEnabled         bool
@@ -157,6 +161,10 @@ func applyWeeklyReportConfig(cfg *Config) {
 		} else {
 			log.Printf("invalid WEEKLY_REPORT_HOUR %q, using default hour %d", hourStr, cfg.WeeklyReportHour)
 		}
+	}
+	cfg.WeeklyHabitRecapEnabled = os.Getenv("WEEKLY_HABIT_RECAP_ENABLED") == envTrue
+	if cfg.WeeklyHabitRecapEnabled && !cfg.WeeklyReportEnabled {
+		log.Printf("WEEKLY_HABIT_RECAP_ENABLED is set but WEEKLY_REPORT_ENABLED is not; weekly habit recap will not run")
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -412,6 +412,41 @@ func TestLoad_WeeklyReport(t *testing.T) {
 		require.Equal(t, time.Sunday, cfg.WeeklyReportDay)
 		require.Equal(t, 8, cfg.WeeklyReportHour)
 	})
+
+	t.Run("parses WEEKLY_HABIT_RECAP_ENABLED=true", func(t *testing.T) {
+		t.Setenv(envTelegramKeyVarConfig, testTokenConfig)
+		t.Setenv(envDatabaseURL, testDatabaseURLConfig)
+		t.Setenv(envWhitelistedUserIDs, "123")
+		t.Setenv("WEEKLY_REPORT_ENABLED", "true")
+		t.Setenv("WEEKLY_HABIT_RECAP_ENABLED", "true")
+
+		cfg, err := Load()
+		require.NoError(t, err)
+		require.True(t, cfg.WeeklyHabitRecapEnabled)
+	})
+
+	t.Run("defaults WEEKLY_HABIT_RECAP_ENABLED to false", func(t *testing.T) {
+		t.Setenv(envTelegramKeyVarConfig, testTokenConfig)
+		t.Setenv(envDatabaseURL, testDatabaseURLConfig)
+		t.Setenv(envWhitelistedUserIDs, "123")
+		t.Setenv("WEEKLY_REPORT_ENABLED", "true")
+
+		cfg, err := Load()
+		require.NoError(t, err)
+		require.False(t, cfg.WeeklyHabitRecapEnabled)
+	})
+
+	t.Run("parses WEEKLY_HABIT_RECAP_ENABLED even when weekly report disabled", func(t *testing.T) {
+		t.Setenv(envTelegramKeyVarConfig, testTokenConfig)
+		t.Setenv(envDatabaseURL, testDatabaseURLConfig)
+		t.Setenv(envWhitelistedUserIDs, "123")
+		t.Setenv("WEEKLY_HABIT_RECAP_ENABLED", "true")
+
+		cfg, err := Load()
+		require.NoError(t, err)
+		require.True(t, cfg.WeeklyHabitRecapEnabled)
+		require.False(t, cfg.WeeklyReportEnabled)
+	})
 }
 
 func TestLoad_Validation(t *testing.T) {

--- a/internal/telemetry/httpclient.go
+++ b/internal/telemetry/httpclient.go
@@ -50,7 +50,8 @@ func (t telegramTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 		return t.base.RoundTrip(req)
 	}
 
-	ctx, span := tracer.Start(req.Context(), "telegram.api "+method,
+	ctx, span := tracer.Start(
+		req.Context(), "telegram.api "+method,
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
 			attribute.String("rpc.system", "telegram"),


### PR DESCRIPTION
## Summary by Sourcery

Add a configurable weekly spending habit recap that is sent alongside the weekly expense report, with proper time range handling, metrics, and documentation.

New Features:
- Introduce a weekly habit recap message that summarizes users' reviewed spending reflections for the previous week and sends it after the weekly expense summary when enabled.
- Add a WEEKLY_HABIT_RECAP_ENABLED configuration flag to control whether the habit recap runs with the weekly report.

Enhancements:
- Integrate OpenTelemetry metrics and logging for weekly habit recap runs, including success and error status tagging.
- Add property-based tests for the habit analyzer and previous-week date range logic to ensure correctness, robustness, and order invariance of the generated summaries.
- Tidy up telemetry span creation calls for chart generation and Telegram HTTP client instrumentation for consistency.

Documentation:
- Document the weekly report and habit recap configuration options in the README and add a dedicated design document describing the weekly habit recap plan and behavior.

Tests:
- Add unit tests for weekly habit recap sending behavior, error handling, and interaction with weekly reports, including OpenTelemetry metric assertions and configuration parsing tests for the new recap flag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional weekly habit recap that can be delivered alongside the existing weekly report.
  * Documented new configuration options for scheduling weekly reporting and enabling the recap.

* **Bug Fixes**
  * Improved handling so the recap is skipped when there’s nothing to summarize.
  * Ensured recap failures don’t prevent the weekly report flow from completing.

* **Tests**
  * Expanded automated coverage for recap delivery, configuration, metrics, and summary formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->